### PR TITLE
Increase timeout to fix integration test.

### DIFF
--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/zalando/ZalandoItemRepository.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/zalando/ZalandoItemRepository.kt
@@ -24,7 +24,7 @@ class ZalandoItemRepository(
     private val website: ZalandoWebsite,
     private val monitorType: ZalandoMonitorType,
     private val randomProxy: RandomProxy? = null,
-    private val timeout: Duration = 20.seconds,
+    private val timeout: Duration = 30.seconds,
 ) : ItemRepository {
     private val json = defaultJson()
     private val userAgent = DESKTOP_USER_AGENTS.random()
@@ -32,7 +32,8 @@ class ZalandoItemRepository(
     override suspend fun getItems(nextPageToken: String?): Page {
         val baseUrl = website.url.toHttpUrl()
         val path =
-            category.paths[website] ?: throw IllegalStateException("No path found for category ${category.name} on website ${website.name}")
+            category.paths[website]
+                ?: throw IllegalStateException("No path found for category ${category.name} on website ${website.name}")
         val urlBuilder = baseUrl.newBuilder().addPathSegment(path)
 
         val page = nextPageToken?.toInt() ?: 0
@@ -42,7 +43,8 @@ class ZalandoItemRepository(
             urlBuilder.addQueryParameter("order", "activation_date")
         }
 
-        val document = defaultJSoupClient(urlBuilder.build().toString(), timeout, randomProxy?.invoke(), userAgent).get()
+        val document =
+            defaultJSoupClient(urlBuilder.build().toString(), timeout, randomProxy?.invoke(), userAgent).get()
         val links: Elements = document.select("article.z5x6ht._0xLoFW.JT3_zV.mo6ZnF._78xIQ- > a")
 
         val items =

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/data/zalando/TestZalandoItemRepository.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/data/zalando/TestZalandoItemRepository.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import kotlin.test.junit5.JUnit5Asserter.assertNotNull
-import kotlin.test.junit5.JUnit5Asserter.fail
 
 class TestZalandoItemRepository {
     @Tag("integration")
@@ -22,16 +21,12 @@ class TestZalandoItemRepository {
                     data.type,
                 )
 
-            try {
-                val result = repository.getItems(null)
-                assert(result.items.isNotEmpty()) { "Expected non-empty items list" }
+            val result = repository.getItems(null)
+            assert(result.items.isNotEmpty()) { "Expected non-empty items list" }
 
-                result.items.forEach { item ->
-                    assertNotNull(item.id) { "Item ID should not be null" }
-                    assertNotNull(item.name) { "Item name should not be null" }
-                }
-            } catch (e: Exception) {
-                fail("Repository threw unexpected exception: ${e.message}", e)
+            result.items.forEach { item ->
+                assertNotNull(item.id) { "Item ID should not be null" }
+                assertNotNull(item.name) { "Item name should not be null" }
             }
         }
 


### PR DESCRIPTION
Increase timeout to fix integration test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased the default timeout for HTTP requests from 20 to 30 seconds.
	- Improved code formatting for better readability.
- **Tests**
	- Simplified test logic by removing unnecessary exception handling in item retrieval tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->