### PR TITLE
Update kotlinx-datetime, kotlinx-serialization-json and cereal libs

### DIFF
--- a/command-monitoring/build.gradle.kts
+++ b/command-monitoring/build.gradle.kts
@@ -4,10 +4,10 @@ plugins {
 }
 
 dependencies {
-    api("com.cereal-automation:cereal-sdk:1.6.0:all")
-    api("com.cereal-automation:cereal-licensing:1.6.0")
+    implementation("com.cereal-automation:cereal-sdk:1.7.0:all")
+    implementation("com.cereal-automation:cereal-licensing:1.7.1")
 
-    api("com.prof18.rssparser:rssparser:6.0.8")
+    implementation("com.prof18.rssparser:rssparser:6.0.8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
     implementation("org.htmlunit:htmlunit:4.7.0")
@@ -30,7 +30,7 @@ dependencies {
     implementation("io.ktor:ktor-client-encoding:3.2.3")
 
     implementation(project(":command"))
-    api(project(":stockx-api-client"))
+    implementation(project(":stockx-api-client"))
     testImplementation(project(":command"))
 }
 

--- a/command-monitoring/build.gradle.kts
+++ b/command-monitoring/build.gradle.kts
@@ -9,10 +9,10 @@ dependencies {
 
     api("com.prof18.rssparser:rssparser:6.0.8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
     implementation("org.htmlunit:htmlunit:4.7.0")
     implementation("org.jsoup:jsoup:1.19.1")
-    api("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
 
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/ScriptNotificationRepository.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/ScriptNotificationRepository.kt
@@ -5,8 +5,9 @@ import com.cereal.command.monitor.models.ItemProperty
 import com.cereal.command.monitor.repository.NotificationRepository
 import com.cereal.sdk.component.notification.NotificationComponent
 import com.cereal.sdk.component.notification.notification
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * Repository responsible for handling the notification creation and dispatch process.
@@ -18,6 +19,7 @@ import kotlinx.datetime.Instant
  * @param discordAvatarUrl The optional avatar URL for the Discord user.
  * @param discordColor The color of the message embed in Discord, expressed as a stringified integer. Defaults to white.
  */
+@OptIn(ExperimentalTime::class)
 class ScriptNotificationRepository(
     private val notificationComponent: NotificationComponent,
     private val discordUsername: String,

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/rss/RssFeedItemRepository.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/rss/RssFeedItemRepository.kt
@@ -7,10 +7,12 @@ import com.cereal.command.monitor.repository.ItemRepository
 import com.cereal.sdk.component.logger.LoggerComponent
 import com.prof18.rssparser.RssParser
 import com.prof18.rssparser.model.RssItem
-import kotlinx.datetime.toKotlinInstant
 import java.text.SimpleDateFormat
 import java.util.Locale
+import kotlin.time.ExperimentalTime
+import kotlin.time.toKotlinInstant
 
+@OptIn(ExperimentalTime::class)
 class RssFeedItemRepository(
     private val rssFeedUrl: String,
     private val logger: LoggerComponent,

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/shopify/ShopifyItemRepository.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/shopify/ShopifyItemRepository.kt
@@ -18,9 +18,11 @@ import io.ktor.http.HttpHeaders
 import java.net.URL
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
 
 private const val PRODUCTS_JSON_PATH = "products.json"
 
+@OptIn(ExperimentalTime::class)
 class ShopifyItemRepository(
     private val logRepository: LogRepository,
     private val website: ShopifyWebsite,

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/shopify/models/Product.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/shopify/models/Product.kt
@@ -1,9 +1,11 @@
 package com.cereal.command.monitor.data.shopify.models
 
-import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
+@OptIn(ExperimentalTime::class)
 @Serializable
 data class Product(
     @SerialName("body_html")

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/models/ItemProperty.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/models/ItemProperty.kt
@@ -1,6 +1,7 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.cereal.command.monitor.models
 
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toLocalDateTime
@@ -9,6 +10,8 @@ import java.text.NumberFormat
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 sealed class ItemProperty(
     val commonName: String,

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MonitorStrategyFactory.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MonitorStrategyFactory.kt
@@ -14,10 +14,12 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
+@OptIn(ExperimentalTime::class)
 object MonitorStrategyFactory {
     fun priceDropMonitorStrategy(): MonitorStrategy {
         return PriceDropMonitorStrategy()

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableMonitorStrategy.kt
@@ -3,8 +3,9 @@ package com.cereal.command.monitor.strategy
 import com.cereal.command.monitor.models.Item
 import com.cereal.command.monitor.models.ItemProperty
 import com.cereal.command.monitor.models.getValue
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * A monitoring strategy that notifies when a new item is detected since a specific point in time.
@@ -19,6 +20,7 @@ import kotlinx.datetime.Instant
  * Provides a [requiresBaseline] method which indicates that the strategy requires an initial baseline
  * or previous item for consistent notification behavior.
  */
+@OptIn(ExperimentalTime::class)
 class NewItemAvailableMonitorStrategy(
     private val since: Instant = Clock.System.now(),
 ) : MonitorStrategy {

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/TestMonitorCommand.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/TestMonitorCommand.kt
@@ -18,15 +18,17 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class TestMonitorCommand {
     private val itemRepository = mockk<ItemRepository>()
     private val notificationRepository = mockk<NotificationRepository>(relaxed = true)
@@ -146,56 +148,56 @@ class TestMonitorCommand {
     fun `test with strategies and verify notifications`(data: TestData) =
         runBlocking {
             coEvery { itemRepository.getItems(null) } returns
-                Page(
-                    items =
-                        listOf(
-                            Item(
-                                id = "foo",
-                                url = "http://cereal-automation.com",
-                                name = "Foo",
-                                properties =
-                                    listOf(
-                                        ItemProperty.PublishDate(Clock.System.now()),
-                                        ItemProperty.Stock(isInStock = true, amount = 1, null),
-                                        ItemProperty.Price(BigDecimal("10.00"), Currency.EUR),
-                                    ),
+                    Page(
+                        items =
+                            listOf(
+                                Item(
+                                    id = "foo",
+                                    url = "http://cereal-automation.com",
+                                    name = "Foo",
+                                    properties =
+                                        listOf(
+                                            ItemProperty.PublishDate(Clock.System.now()),
+                                            ItemProperty.Stock(isInStock = true, amount = 1, null),
+                                            ItemProperty.Price(BigDecimal("10.00"), Currency.EUR),
+                                        ),
+                                ),
+                                Item(
+                                    id = "bar",
+                                    url = "http://cereal-automation.com",
+                                    name = "Bar",
+                                    properties =
+                                        listOf(
+                                            ItemProperty.PublishDate(Clock.System.now()),
+                                            ItemProperty.Stock(isInStock = false, amount = 0, null),
+                                            ItemProperty.Price(BigDecimal("10.00"), Currency.EUR),
+                                        ),
+                                ),
+                                Item(
+                                    id = "baz",
+                                    url = "http://cereal-automation.com",
+                                    name = "Baz",
+                                    properties =
+                                        listOf(
+                                            ItemProperty.PublishDate(Clock.System.now().minus(60.seconds)),
+                                            ItemProperty.Stock(isInStock = false, amount = 0, null),
+                                            ItemProperty.Price(BigDecimal("10.00"), Currency.EUR),
+                                        ),
+                                ),
+                                Item(
+                                    id = "cux",
+                                    url = "http://cereal-automation.com",
+                                    name = "Foo",
+                                    properties =
+                                        listOf(
+                                            ItemProperty.PublishDate(Clock.System.now()),
+                                            ItemProperty.Stock(isInStock = true, amount = 1, null),
+                                            ItemProperty.Price(BigDecimal("50.00"), Currency.EUR),
+                                        ),
+                                ),
                             ),
-                            Item(
-                                id = "bar",
-                                url = "http://cereal-automation.com",
-                                name = "Bar",
-                                properties =
-                                    listOf(
-                                        ItemProperty.PublishDate(Clock.System.now()),
-                                        ItemProperty.Stock(isInStock = false, amount = 0, null),
-                                        ItemProperty.Price(BigDecimal("10.00"), Currency.EUR),
-                                    ),
-                            ),
-                            Item(
-                                id = "baz",
-                                url = "http://cereal-automation.com",
-                                name = "Baz",
-                                properties =
-                                    listOf(
-                                        ItemProperty.PublishDate(Clock.System.now().minus(60.seconds)),
-                                        ItemProperty.Stock(isInStock = false, amount = 0, null),
-                                        ItemProperty.Price(BigDecimal("10.00"), Currency.EUR),
-                                    ),
-                            ),
-                            Item(
-                                id = "cux",
-                                url = "http://cereal-automation.com",
-                                name = "Foo",
-                                properties =
-                                    listOf(
-                                        ItemProperty.PublishDate(Clock.System.now()),
-                                        ItemProperty.Stock(isInStock = true, amount = 1, null),
-                                        ItemProperty.Price(BigDecimal("50.00"), Currency.EUR),
-                                    ),
-                            ),
-                        ),
-                    nextPageToken = null,
-                )
+                        nextPageToken = null,
+                    )
 
             val monitorCommand =
                 MonitorCommand(

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/data/rss/TestRssFeedItemRepository.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/data/rss/TestRssFeedItemRepository.kt
@@ -10,10 +10,12 @@ import com.prof18.rssparser.model.RssItem
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
+@OptIn(ExperimentalTime::class)
 class TestRssFeedItemRepository {
     @Test
     fun testParseRss() =

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableCommandExecutionScriptStrategyTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableCommandExecutionScriptStrategyTest.kt
@@ -3,11 +3,13 @@ package com.cereal.command.monitor.strategy
 import com.cereal.command.monitor.models.Item
 import com.cereal.command.monitor.models.ItemProperty
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
+@OptIn(ExperimentalTime::class)
 class NewItemAvailableCommandExecutionScriptStrategyTest {
     @Test
     fun `shouldNotify returns true for item with publish date after since`() {

--- a/command/build.gradle.kts
+++ b/command/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 dependencies {
-    api("com.cereal-automation:cereal-sdk:1.6.0:all")
-    api("com.cereal-automation:cereal-licensing:1.6.0")
+    implementation("com.cereal-automation:cereal-sdk:1.7.0:all")
+    implementation("com.cereal-automation:cereal-licensing:1.7.1")
 
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")

--- a/command/build.gradle.kts
+++ b/command/build.gradle.kts
@@ -7,15 +7,13 @@ dependencies {
     api("com.cereal-automation:cereal-sdk:1.6.0:all")
     api("com.cereal-automation:cereal-licensing:1.6.0")
 
-    api("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
-
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
     testImplementation("io.mockk:mockk:1.14.5")
     testImplementation("com.cereal-automation:cereal-test-utils:1.6.0")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
 }
 

--- a/command/src/main/kotlin/com/cereal/script/CommandExecutionScript.kt
+++ b/command/src/main/kotlin/com/cereal/script/CommandExecutionScript.kt
@@ -10,12 +10,13 @@ import com.cereal.sdk.ExecutionResult
 import com.cereal.sdk.component.ComponentProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.collect
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.Instant
 import kotlinx.datetime.until
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * The Monitor class handles monitoring of items using specified strategies and repositories.
@@ -23,6 +24,7 @@ import kotlin.time.Duration.Companion.seconds
  * @property scriptId Unique identifier of the script.
  * @property scriptPublicKey Optional public key for license validation.
  */
+@OptIn(ExperimentalTime::class)
 class CommandExecutionScript(
     private val scriptId: String,
     private val scriptPublicKey: String?,

--- a/script-bdga-store/build.gradle.kts
+++ b/script-bdga-store/build.gradle.kts
@@ -3,7 +3,12 @@ plugins {
 }
 
 dependencies {
+    implementation("com.cereal-automation:cereal-sdk:1.7.0:all")
+    implementation("com.cereal-automation:cereal-licensing:1.7.1")
+
     implementation(project(":script-common"))
+    implementation(project(":command"))
+    implementation(project(":command-monitoring"))
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")

--- a/script-common/build.gradle.kts
+++ b/script-common/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    api(project(":command"))
-    api(project(":command-monitoring"))
+    implementation("com.cereal-automation:cereal-sdk:1.7.0:all")
+    implementation("com.cereal-automation:cereal-licensing:1.7.1")
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")

--- a/script-nike/build.gradle.kts
+++ b/script-nike/build.gradle.kts
@@ -3,7 +3,12 @@ plugins {
 }
 
 dependencies {
+    implementation("com.cereal-automation:cereal-sdk:1.7.0:all")
+    implementation("com.cereal-automation:cereal-licensing:1.7.1")
+
     implementation(project(":script-common"))
+    implementation(project(":command"))
+    implementation(project(":command-monitoring"))
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")

--- a/script-nike/src/main/kotlin/com/cereal/nike/NikeScript.kt
+++ b/script-nike/src/main/kotlin/com/cereal/nike/NikeScript.kt
@@ -9,9 +9,11 @@ import com.cereal.script.commands.Command
 import com.cereal.sdk.ExecutionResult
 import com.cereal.sdk.Script
 import com.cereal.sdk.component.ComponentProvider
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class NikeScript : Script<NikeConfiguration> {
     private val commandExecutionScript =
         CommandExecutionScript(

--- a/script-sample/build.gradle.kts
+++ b/script-sample/build.gradle.kts
@@ -3,7 +3,12 @@ plugins {
 }
 
 dependencies {
+    implementation("com.cereal-automation:cereal-sdk:1.7.0:all")
+    implementation("com.cereal-automation:cereal-licensing:1.7.1")
+
     implementation(project(":script-common"))
+    implementation(project(":command"))
+    implementation(project(":command-monitoring"))
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")

--- a/script-sample/src/main/kotlin/com/cereal/sample/SampleScript.kt
+++ b/script-sample/src/main/kotlin/com/cereal/sample/SampleScript.kt
@@ -7,9 +7,11 @@ import com.cereal.script.CommandExecutionScript
 import com.cereal.sdk.ExecutionResult
 import com.cereal.sdk.Script
 import com.cereal.sdk.component.ComponentProvider
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class SampleScript : Script<SampleConfiguration> {
     private val commandExecutionScript =
         CommandExecutionScript(

--- a/script-snkrs/build.gradle.kts
+++ b/script-snkrs/build.gradle.kts
@@ -3,7 +3,12 @@ plugins {
 }
 
 dependencies {
+    implementation("com.cereal-automation:cereal-sdk:1.7.0:all")
+    implementation("com.cereal-automation:cereal-licensing:1.7.1")
+
     implementation(project(":script-common"))
+    implementation(project(":command"))
+    implementation(project(":command-monitoring"))
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")

--- a/script-zalando/build.gradle.kts
+++ b/script-zalando/build.gradle.kts
@@ -3,7 +3,12 @@ plugins {
 }
 
 dependencies {
+    implementation("com.cereal-automation:cereal-sdk:1.7.0:all")
+    implementation("com.cereal-automation:cereal-licensing:1.7.1")
+
     implementation(project(":script-common"))
+    implementation(project(":command"))
+    implementation(project(":command-monitoring"))
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")

--- a/script-zalando/src/main/kotlin/com/cereal/zalando/ZalandoScript.kt
+++ b/script-zalando/src/main/kotlin/com/cereal/zalando/ZalandoScript.kt
@@ -9,9 +9,11 @@ import com.cereal.script.commands.Command
 import com.cereal.sdk.ExecutionResult
 import com.cereal.sdk.Script
 import com.cereal.sdk.component.ComponentProvider
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class ZalandoScript : Script<ZalandoConfiguration> {
     private val commandExecutionScript =
         CommandExecutionScript(

--- a/stockx-api-client/build.gradle
+++ b/stockx-api-client/build.gradle
@@ -3,7 +3,7 @@ version '1.0.0'
 
 buildscript {
     ext.kotlin_version = '1.9.23'
-    ext.ktor_version = '2.3.9'
+    ext.ktor_version = '3.2.3'
     ext.spotless_version = "6.25.0"
 
     repositories {


### PR DESCRIPTION
- Update kotlinx-datetime, kotlinx-serialization-json and cereal libs
- Use implementation instead of api everywhere to overcome an issue related to incorrect version usage for kotlinx-serialization-json.

Note that each script gradle module now has to manually add:
```
implementation("com.cereal-automation:cereal-sdk:1.7.0:all")
implementation("com.cereal-automation:cereal-licensing:1.7.1")

implementation(project(":command"))
implementation(project(":command-monitoring"))
```

I'll unify this in another PR (together with versions catalogs).