### PR TITLE
Add notifyOnInitialRun option to StockAvailableMonitorStrategy

### DIFF
--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategy.kt
@@ -42,22 +42,24 @@ class StockAvailableMonitorStrategy(
 
     private fun generateInitialRunMessage(item: Item): String? {
         val currentStock = item.getValue<ItemProperty.Stock>()
-        
+
         // Check if the item itself is in stock
         if (currentStock?.isInStock == true) {
             return "${item.name} is in stock (${currentStock.stockValue()})!"
         }
-        
+
         // Check if any variants are in stock
-        val inStockVariants = item.variants.filter { 
-            it.requireValue<ItemProperty.Stock>().isInStock 
-        }
-        
-        return if (inStockVariants.isNotEmpty()) {
-            val variantMessages = inStockVariants.map { variant ->
-                val stockLevelString = variant.getValue<ItemProperty.Stock>()?.stockValue()
-                listOfNotNull("Variant ${variant.name} is in stock", stockLevelString).joinToString(": ")
+        val inStockVariants =
+            item.variants.filter {
+                it.requireValue<ItemProperty.Stock>().isInStock
             }
+
+        return if (inStockVariants.isNotEmpty()) {
+            val variantMessages =
+                inStockVariants.map { variant ->
+                    val stockLevelString = variant.getValue<ItemProperty.Stock>()?.stockValue()
+                    listOfNotNull("Variant ${variant.name} is in stock", stockLevelString).joinToString(": ")
+                }
             variantMessages.joinToString("\n")
         } else {
             null

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategyTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategyTest.kt
@@ -9,8 +9,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-class StockAvailableCommandExecutionScriptStrategyTest {
+class StockAvailableMonitorStrategyTest {
     private val monitorStrategy = StockAvailableMonitorStrategy()
+    private val monitorStrategyWithInitialRun = StockAvailableMonitorStrategy(notifyOnInitialRun = true)
 
     @Test
     fun `should notify when stock is available`() {
@@ -216,5 +217,158 @@ class StockAvailableCommandExecutionScriptStrategyTest {
         val result = runBlocking { monitorStrategy.shouldNotify(currentItem, previousItem) }
 
         assertNull(result)
+    }
+
+    // Tests for initial run notification functionality
+
+    @Test
+    fun `should notify on initial run when item is in stock with notifyOnInitialRun enabled`() {
+        val item = Item(
+            id = "1",
+            url = "http://example.com/item/1",
+            name = "Test Item",
+            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
+        )
+
+        val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
+
+        assertEquals("Test Item is in stock (5)!", result)
+    }
+
+    @Test
+    fun `should not notify on initial run when item is not in stock with notifyOnInitialRun enabled`() {
+        val item = Item(
+            id = "1",
+            url = "http://example.com/item/1",
+            name = "Test Item",
+            properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+        )
+
+        val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should notify on initial run when variants are in stock with notifyOnInitialRun enabled`() {
+        val item = Item(
+            id = "1",
+            url = "http://example.com/item/1",
+            name = "Test Item",
+            properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+            variants = listOf(
+                Variant(
+                    id = "variant1",
+                    name = "Size M",
+                    styleId = null,
+                    properties = listOf(ItemProperty.Stock(isInStock = true, amount = 3, "LOW")),
+                ),
+                Variant(
+                    id = "variant2",
+                    name = "Size L",
+                    styleId = null,
+                    properties = listOf(ItemProperty.Stock(isInStock = true, amount = null, "HIGH")),
+                ),
+            ),
+        )
+
+        val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
+
+        assertEquals("Variant Size M is in stock: 3\nVariant Size L is in stock: HIGH", result)
+    }
+
+    @Test
+    fun `should not notify on initial run when no variants are in stock with notifyOnInitialRun enabled`() {
+        val item = Item(
+            id = "1",
+            url = "http://example.com/item/1",
+            name = "Test Item",
+            properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+            variants = listOf(
+                Variant(
+                    id = "variant1",
+                    name = "Size M",
+                    styleId = null,
+                    properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+                ),
+            ),
+        )
+
+        val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should not notify on initial run with default strategy (backwards compatibility)`() {
+        // This test verifies that the default strategy requires a baseline
+        // In practice, the monitoring system won't call shouldNotify with null previousItem
+        // for strategies that require baseline, but we test the behavior directly here
+        val item = Item(
+            id = "1",
+            url = "http://example.com/item/1",
+            name = "Test Item",
+            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
+        )
+
+        // The default strategy should not notify on initial run even if called directly
+        // This is a defensive test - in practice this won't happen due to requiresBaseline check
+        val result = runBlocking { monitorStrategy.shouldNotify(item, null) }
+
+        // The strategy should return null because it doesn't have notifyOnInitialRun enabled
+        assertNull(result)
+    }
+
+    @Test
+    fun `should return correct requiresBaseline value for default strategy`() {
+        assert(monitorStrategy.requiresBaseline())
+    }
+
+    @Test
+    fun `should return correct requiresBaseline value for initial run strategy`() {
+        assert(!monitorStrategyWithInitialRun.requiresBaseline())
+    }
+
+    @Test
+    fun `should handle mixed scenario with item and variants in stock on initial run`() {
+        val item = Item(
+            id = "1",
+            url = "http://example.com/item/1",
+            name = "Test Item",
+            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 2, "LOW")),
+            variants = listOf(
+                Variant(
+                    id = "variant1",
+                    name = "Size M",
+                    styleId = null,
+                    properties = listOf(ItemProperty.Stock(isInStock = true, amount = 1, "LOW")),
+                ),
+            ),
+        )
+
+        val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
+
+        // Should prioritize item-level notification over variant notifications
+        assertEquals("Test Item is in stock (2)!", result)
+    }
+
+    @Test
+    fun `should work normally with previous item when notifyOnInitialRun is enabled`() {
+        val previousItem = Item(
+            id = "1",
+            url = "http://example.com/item/1",
+            name = "Test Item",
+            properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+        )
+        val currentItem = Item(
+            id = "1",
+            url = "http://example.com/item/1",
+            name = "Test Item",
+            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
+        )
+
+        val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(currentItem, previousItem) }
+
+        assertEquals("Test Item is in stock (5)!", result)
     }
 }

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategyTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategyTest.kt
@@ -223,12 +223,13 @@ class StockAvailableMonitorStrategyTest {
 
     @Test
     fun `should notify on initial run when item is in stock with notifyOnInitialRun enabled`() {
-        val item = Item(
-            id = "1",
-            url = "http://example.com/item/1",
-            name = "Test Item",
-            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
-        )
+        val item =
+            Item(
+                id = "1",
+                url = "http://example.com/item/1",
+                name = "Test Item",
+                properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
+            )
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
@@ -237,12 +238,13 @@ class StockAvailableMonitorStrategyTest {
 
     @Test
     fun `should not notify on initial run when item is not in stock with notifyOnInitialRun enabled`() {
-        val item = Item(
-            id = "1",
-            url = "http://example.com/item/1",
-            name = "Test Item",
-            properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
-        )
+        val item =
+            Item(
+                id = "1",
+                url = "http://example.com/item/1",
+                name = "Test Item",
+                properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+            )
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
@@ -251,26 +253,28 @@ class StockAvailableMonitorStrategyTest {
 
     @Test
     fun `should notify on initial run when variants are in stock with notifyOnInitialRun enabled`() {
-        val item = Item(
-            id = "1",
-            url = "http://example.com/item/1",
-            name = "Test Item",
-            properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
-            variants = listOf(
-                Variant(
-                    id = "variant1",
-                    name = "Size M",
-                    styleId = null,
-                    properties = listOf(ItemProperty.Stock(isInStock = true, amount = 3, "LOW")),
-                ),
-                Variant(
-                    id = "variant2",
-                    name = "Size L",
-                    styleId = null,
-                    properties = listOf(ItemProperty.Stock(isInStock = true, amount = null, "HIGH")),
-                ),
-            ),
-        )
+        val item =
+            Item(
+                id = "1",
+                url = "http://example.com/item/1",
+                name = "Test Item",
+                properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+                variants =
+                    listOf(
+                        Variant(
+                            id = "variant1",
+                            name = "Size M",
+                            styleId = null,
+                            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 3, "LOW")),
+                        ),
+                        Variant(
+                            id = "variant2",
+                            name = "Size L",
+                            styleId = null,
+                            properties = listOf(ItemProperty.Stock(isInStock = true, amount = null, "HIGH")),
+                        ),
+                    ),
+            )
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
@@ -279,20 +283,22 @@ class StockAvailableMonitorStrategyTest {
 
     @Test
     fun `should not notify on initial run when no variants are in stock with notifyOnInitialRun enabled`() {
-        val item = Item(
-            id = "1",
-            url = "http://example.com/item/1",
-            name = "Test Item",
-            properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
-            variants = listOf(
-                Variant(
-                    id = "variant1",
-                    name = "Size M",
-                    styleId = null,
-                    properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
-                ),
-            ),
-        )
+        val item =
+            Item(
+                id = "1",
+                url = "http://example.com/item/1",
+                name = "Test Item",
+                properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+                variants =
+                    listOf(
+                        Variant(
+                            id = "variant1",
+                            name = "Size M",
+                            styleId = null,
+                            properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+                        ),
+                    ),
+            )
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
@@ -304,12 +310,13 @@ class StockAvailableMonitorStrategyTest {
         // This test verifies that the default strategy requires a baseline
         // In practice, the monitoring system won't call shouldNotify with null previousItem
         // for strategies that require baseline, but we test the behavior directly here
-        val item = Item(
-            id = "1",
-            url = "http://example.com/item/1",
-            name = "Test Item",
-            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
-        )
+        val item =
+            Item(
+                id = "1",
+                url = "http://example.com/item/1",
+                name = "Test Item",
+                properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
+            )
 
         // The default strategy should not notify on initial run even if called directly
         // This is a defensive test - in practice this won't happen due to requiresBaseline check
@@ -331,20 +338,22 @@ class StockAvailableMonitorStrategyTest {
 
     @Test
     fun `should handle mixed scenario with item and variants in stock on initial run`() {
-        val item = Item(
-            id = "1",
-            url = "http://example.com/item/1",
-            name = "Test Item",
-            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 2, "LOW")),
-            variants = listOf(
-                Variant(
-                    id = "variant1",
-                    name = "Size M",
-                    styleId = null,
-                    properties = listOf(ItemProperty.Stock(isInStock = true, amount = 1, "LOW")),
-                ),
-            ),
-        )
+        val item =
+            Item(
+                id = "1",
+                url = "http://example.com/item/1",
+                name = "Test Item",
+                properties = listOf(ItemProperty.Stock(isInStock = true, amount = 2, "LOW")),
+                variants =
+                    listOf(
+                        Variant(
+                            id = "variant1",
+                            name = "Size M",
+                            styleId = null,
+                            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 1, "LOW")),
+                        ),
+                    ),
+            )
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
@@ -354,18 +363,20 @@ class StockAvailableMonitorStrategyTest {
 
     @Test
     fun `should work normally with previous item when notifyOnInitialRun is enabled`() {
-        val previousItem = Item(
-            id = "1",
-            url = "http://example.com/item/1",
-            name = "Test Item",
-            properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
-        )
-        val currentItem = Item(
-            id = "1",
-            url = "http://example.com/item/1",
-            name = "Test Item",
-            properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
-        )
+        val previousItem =
+            Item(
+                id = "1",
+                url = "http://example.com/item/1",
+                name = "Test Item",
+                properties = listOf(ItemProperty.Stock(isInStock = false, amount = 0, "OOS")),
+            )
+        val currentItem =
+            Item(
+                id = "1",
+                url = "http://example.com/item/1",
+                name = "Test Item",
+                properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
+            )
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(currentItem, previousItem) }
 


### PR DESCRIPTION
At some point we need to rethink the setup of the available strategies we have related to detecting new items because it gets more and more complex.