### PR TITLE
Fix datadome cookie issue

### DIFF
--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/DataDomeCookieManager.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/DataDomeCookieManager.kt
@@ -76,7 +76,7 @@ internal class DataDomeCookieManager(
             val appVersion = playStoreApiClient.getAppVersion()
             val cid = UUID.randomUUID().toString().replace("-", "").take(64)
             val requestUrlEncoded = URLEncoder.encode("$baseUrl$originalRequestPath", StandardCharsets.UTF_8.toString())
-            val userAgent = "TGTG/$appVersion Dalvik/2.1.0 (Linux; U; Android 14; Pixel 7 Pro Build/UQ1A.240105.004)"
+            val userAgent = TgtgConstants.USER_AGENT_TEMPLATE.format(appVersion)
             val timestamp = System.currentTimeMillis()
             val eventsJson =
                 "[%7B%22id%22:1,%22message%22:%22response validation%22,%22source%22:%22sdk%22,%22date%22:$timestamp%7D]"

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/TgtgApiClient.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/TgtgApiClient.kt
@@ -60,7 +60,7 @@ class TgtgApiClient(
                 HttpHeaders.Accept to "application/json",
                 HttpHeaders.AcceptLanguage to "en-US",
                 HttpHeaders.AcceptEncoding to "gzip",
-                HttpHeaders.UserAgent to "TGTG/$appVersion Dalvik/2.1.0 (Linux; Android 12; SM-G920V Build/MMB29K)",
+                HttpHeaders.UserAgent to TgtgConstants.USER_AGENT_TEMPLATE.format(appVersion),
                 "x-correlation-id" to config.correlationId,
             )
         val cookieStorage: CookiesStorage = dataDomeManager.createCookieStorage(config)

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/TgtgConstants.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/TgtgConstants.kt
@@ -1,0 +1,5 @@
+package com.cereal.command.monitor.data.tgtg.apiclients
+
+internal object TgtgConstants {
+    const val USER_AGENT_TEMPLATE = "TGTG/%s Dalvik/2.1.0 (Linux; U; Android 14; Pixel 7 Pro Build/UQ1A.240105.004)"
+}


### PR DESCRIPTION
Use the same user agent in datadome cookie request and all tgtg api requests.