### PR TITLE
Log waiting time before next run in ExecuteCommandsInteractor

### DIFF
--- a/command/src/main/kotlin/com/cereal/script/interactor/ExecuteCommandsInteractor.kt
+++ b/command/src/main/kotlin/com/cereal/script/interactor/ExecuteCommandsInteractor.kt
@@ -61,7 +61,7 @@ class ExecuteCommandsInteractor(
                             currentContext = emitted
                             emit(currentContext)
                         }
-                    
+
                     // Log waiting time before next run
                     if (decision is RunDecision.RunRepeat && decision.startDelay.isPositive()) {
                         val seconds = decision.startDelay.inWholeSeconds


### PR DESCRIPTION
So that the user knows that he must wait.