### PR TITLE
fix: revert HTTP client caching to restore DataDome cookie/authEmail flow

### DIFF
--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/DataDomeCookieManager.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/DataDomeCookieManager.kt
@@ -6,7 +6,6 @@ import com.cereal.command.monitor.data.tgtg.TgtgConfig
 import com.cereal.command.monitor.data.tgtg.apiclients.models.DataDomeCookieResponse
 import com.cereal.script.repository.LogRepository
 import com.cereal.sdk.models.proxy.Proxy
-import io.ktor.client.HttpClient
 import io.ktor.client.plugins.cookies.AcceptAllCookiesStorage
 import io.ktor.client.plugins.cookies.CookiesStorage
 import io.ktor.client.request.forms.FormDataContent
@@ -35,11 +34,6 @@ internal class DataDomeCookieManager(
     private val configStore: TgtgConfigStore,
     private val json: Json = defaultJson(),
 ) {
-    private var cachedHttpClient: HttpClient? = null
-
-    private fun getHttpClient(): HttpClient =
-        cachedHttpClient ?: defaultHttpClient(timeout = timeout, httpProxy = httpProxy).also { cachedHttpClient = it }
-
     companion object {
         private const val DATA_DOME_COOKIE_NAME = "datadome"
     }
@@ -118,7 +112,7 @@ internal class DataDomeCookieManager(
                     append("d_ifv", UUID.randomUUID().toString().replace("-", ""))
                 }
 
-            val httpClient = getHttpClient()
+            val httpClient = defaultHttpClient(timeout = timeout, httpProxy = httpProxy)
             val response =
                 httpClient.post("https://api-sdk.datadome.co/sdk/") {
                     headers {

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/HttpExecutor.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/tgtg/apiclients/HttpExecutor.kt
@@ -16,17 +16,13 @@ internal class HttpExecutor(
     private val cookieManager: DataDomeCookieManager,
     private val httpClientFactory: suspend () -> HttpClient,
 ) {
-    private var cachedClient: HttpClient? = null
-
-    private suspend fun getClient(): HttpClient = cachedClient ?: httpClientFactory().also { cachedClient = it }
-
     suspend fun <T> postWith403Retry(
         path: String,
         authHeader: String? = null,
         bodyBuilder: () -> String,
         decode: (String) -> T,
     ): T? {
-        val client = getClient()
+        val client = httpClientFactory()
         val response =
             client.post("${baseUrl}$path") {
                 authHeader?.let { headers[HttpHeaders.Authorization] = it }
@@ -36,8 +32,9 @@ internal class HttpExecutor(
             logRepository.debug("Received 403 for $path. Attempting DataDome cookie fetch.")
             val cookie = cookieManager.fetch(path)
             if (cookie != null) {
+                val retryClient = httpClientFactory() // picks up stored cookie via new storage
                 val retryResponse =
-                    client.post("${baseUrl}$path") {
+                    retryClient.post("${baseUrl}$path") {
                         authHeader?.let { headers[HttpHeaders.Authorization] = it }
                         setBody(bodyBuilder())
                     }


### PR DESCRIPTION
## Problem

After PR #46 (performance optimization), the `authByEmail` endpoint consistently returns a captcha URL instead of a polling ID, meaning TGTG no longer trusts the request.

The root cause was two client caching changes introduced in commit `1cfa111`:
1. **`HttpExecutor`** — introduced `cachedClient` so the same `HttpClient` instance was reused across all requests, including the 403 retry.
2. **`DataDomeCookieManager`** — introduced `cachedHttpClient` so the DataDome SDK call also reused a single client.
The 403 retry flow is intentionally designed around creating a **new** `HttpClient` after fetching the DataDome cookie, so the new client initialises its `CookiesStorage` with the freshly stored cookie. Reusing the cached client meant the retry went out without the DataDome cookie, causing TGTG's backend to flag the request as untrusted and return a captcha challenge.

## Changes
- Removed `cachedClient`/`getClient()` from `HttpExecutor` — the 403 retry path now creates a fresh client via `httpClientFactory()` as originally intended.
- Removed `cachedHttpClient`/`getHttpClient()` from `DataDomeCookieManager` — the DataDome SDK call creates a fresh client each time.

## Impact
No behaviour change for the happy path. The performance optimisation is lost, but correctness is restored — auth will work again without hitting the captcha wall.