### PR TITLE
The command chain failed successfully

### DIFF
--- a/command/src/main/kotlin/com/cereal/script/interactor/CommandFlowExt.kt
+++ b/command/src/main/kotlin/com/cereal/script/interactor/CommandFlowExt.kt
@@ -32,7 +32,7 @@ fun <T> Flow<T>.withRetry(
     this.retryWhen { cause, attempt ->
         // Propagate cooperative cancellation without logging or retrying
         if (cause is CancellationException) return@retryWhen false
-        if (cause is RuntimeException || cause is UnrecoverableException || cause is InvalidChainContextException) {
+        if (cause is RuntimeException || cause is UnrecoverableException || cause is InvalidChainContextException || cause is CommandSuccessException) {
             // Runtime exceptions, UnrecoverableExceptions, and InvalidChainContextExceptions are not retried at the command level.
             // InvalidChainContextExceptions will be handled at the command chain level to restart the entire chain.
             val message =
@@ -40,9 +40,10 @@ fun <T> Flow<T>.withRetry(
                     is InvalidChainContextException -> "Restarting '$action' due to an invalid state"
                     is UnrecoverableException -> "Skip retrying '$action' due to unrecoverable error"
                     is RuntimeException -> "Skip retrying '$action' due to unhandled error"
+                    is CommandSuccessException -> null
                     else -> "Skip retrying '$action'"
                 }
-            logRepository.info(message)
+            message?.let { logRepository.info(it) }
             false
         } else if (attempt < RETRY_ATTEMPTS_TOTAL) {
             val delayTime =
@@ -82,7 +83,7 @@ fun Flow<ChainContext>.withLogging(
             logRepository.info("Finished '$action'.")
         }.onCompletion { error ->
             error?.let {
-                if (error !is CancellationException) {
+                if (error !is CancellationException && error !is CommandSuccessException) {
                     logRepository.debug("Error executing '$action': \n${error.stackTraceToString()}")
                 }
             }

--- a/command/src/main/kotlin/com/cereal/script/interactor/CommandFlowExt.kt
+++ b/command/src/main/kotlin/com/cereal/script/interactor/CommandFlowExt.kt
@@ -32,7 +32,11 @@ fun <T> Flow<T>.withRetry(
     this.retryWhen { cause, attempt ->
         // Propagate cooperative cancellation without logging or retrying
         if (cause is CancellationException) return@retryWhen false
-        if (cause is RuntimeException || cause is UnrecoverableException || cause is InvalidChainContextException || cause is CommandSuccessException) {
+        if (cause is RuntimeException ||
+            cause is UnrecoverableException ||
+            cause is InvalidChainContextException ||
+            cause is CommandSuccessException)
+        {
             // Runtime exceptions, UnrecoverableExceptions, and InvalidChainContextExceptions are not retried at the command level.
             // InvalidChainContextExceptions will be handled at the command chain level to restart the entire chain.
             val message =

--- a/command/src/main/kotlin/com/cereal/script/interactor/CommandFlowExt.kt
+++ b/command/src/main/kotlin/com/cereal/script/interactor/CommandFlowExt.kt
@@ -35,8 +35,8 @@ fun <T> Flow<T>.withRetry(
         if (cause is RuntimeException ||
             cause is UnrecoverableException ||
             cause is InvalidChainContextException ||
-            cause is CommandSuccessException)
-        {
+            cause is CommandSuccessException
+        ) {
             // Runtime exceptions, UnrecoverableExceptions, and InvalidChainContextExceptions are not retried at the command level.
             // InvalidChainContextExceptions will be handled at the command chain level to restart the entire chain.
             val message =

--- a/command/src/main/kotlin/com/cereal/script/interactor/CommandSuccessException.kt
+++ b/command/src/main/kotlin/com/cereal/script/interactor/CommandSuccessException.kt
@@ -1,0 +1,10 @@
+package com.cereal.script.interactor
+
+/**
+ * Exception that indicates a command has finished successfully but shouldn't continue its own execution (e.g., skip).
+ * When this exception is thrown, it's treated as a successful completion of the command.
+ */
+class CommandSuccessException(
+    message: String? = null,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/command/src/main/kotlin/com/cereal/script/interactor/ExecuteCommandsInteractor.kt
+++ b/command/src/main/kotlin/com/cereal/script/interactor/ExecuteCommandsInteractor.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 
 /**
@@ -56,11 +59,15 @@ class ExecuteCommandsInteractor(
                     applyDecisionDelay(decision)
 
                     // Execute the command and emit updates
+                    var shouldContinue = true
                     executeCommand(command, currentContext)
-                        .collect { emitted ->
-                            currentContext = emitted
+                        .collect { result ->
+                            currentContext = result.context
+                            shouldContinue = result.shouldContinue
                             emit(currentContext)
                         }
+
+                    if (!shouldContinue) return@flow
 
                     // Log waiting time before next run
                     if (decision is RunDecision.RunRepeat && decision.startDelay.isPositive()) {
@@ -119,12 +126,41 @@ class ExecuteCommandsInteractor(
     private fun executeCommand(
         command: Command,
         context: ChainContext,
-    ): Flow<ChainContext> =
+    ): Flow<CommandResult> =
         flow {
-            command.execute(context)
-            emit(context)
+            try {
+                command.execute(context)
+                emit(CommandResult(context, shouldContinue = true))
+            } catch (e: CommandSuccessException) {
+                e.message?.let { logRepository.info(it) }
+                emit(CommandResult(context, shouldContinue = false))
+            }
         }.withRetry(command.getDescription(), logRepository)
             .withLogging(command.getDescription(), logRepository)
+
+    private fun Flow<CommandResult>.withLogging(
+        action: String,
+        logRepository: LogRepository,
+    ): Flow<CommandResult> =
+        this
+            .onStart {
+                logRepository.info("Starting $action.")
+            }.onEach { result ->
+                if (result.shouldContinue) {
+                    logRepository.info("Finished '$action'.")
+                }
+            }.onCompletion { error ->
+                error?.let {
+                    if (error !is CancellationException && error !is CommandSuccessException) {
+                        logRepository.debug("Error executing '$action': \n${error.stackTraceToString()}")
+                    }
+                }
+            }
+
+    private data class CommandResult(
+        val context: ChainContext,
+        val shouldContinue: Boolean,
+    )
 
     /**
      * Create a shallow copy of the given ChainContext.


### PR DESCRIPTION
The idea is that, when a command has already been completed, we can notify the command chain so that it can be stopped without generating an error.

For example, if an account has already entered a raffle, I want to show a success state in Cereal.