### PR TITLE
Replace String? return with NotifyResult sealed class on MonitorStrategy

### DIFF
--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/EqualsOrBelowPriceMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/EqualsOrBelowPriceMonitorStrategy.kt
@@ -34,12 +34,12 @@ class EqualsOrBelowPriceMonitorStrategy(
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,
-    ): String? {
+    ): MonitorStrategy.NotifyResult {
         val itemPrice = item.requireValue<ItemProperty.Price>()
         val previousItemPrice = previousItem?.requireValue<ItemProperty.Price>()
 
         // Do not notify when the price is the same as before.
-        if (itemPrice.value == previousItemPrice?.value) return null
+        if (itemPrice.value == previousItemPrice?.value) return MonitorStrategy.NotifyResult.Skip("Price unchanged")
 
         if (itemPrice.currency.code != currency.code) {
             throw CurrencyMismatchException(itemPrice.currency, currency)
@@ -48,9 +48,9 @@ class EqualsOrBelowPriceMonitorStrategy(
         val isCheaper = itemPrice.value <= price.min(previousItemPrice?.value ?: price)
 
         return if (isCheaper) {
-            "${item.name} is available for $itemPrice"
+            MonitorStrategy.NotifyResult.Notify("${item.name} is available for $itemPrice")
         } else {
-            null
+            MonitorStrategy.NotifyResult.Skip("Price not below threshold")
         }
     }
 

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommand.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommand.kt
@@ -21,7 +21,7 @@ class ExecuteStrategyCommand(
     private val previousItem: Item?,
 ) {
     suspend fun execute() {
-        val message =
+        val result =
             try {
                 strategy.shouldNotify(item, previousItem)
             } catch (e: Exception) {
@@ -31,16 +31,20 @@ class ExecuteStrategyCommand(
                 null
             }
 
-        if (message != null) {
-            try {
-                logRepository.info(
-                    "Notification triggered for item '${item.name}': $message",
-                )
-
-                notificationRepository.notify(message, item)
-            } catch (e: Exception) {
-                logRepository.info("Unable to create a notification for '${item.name}' because: ${e.message}")
+        when (result) {
+            is MonitorStrategy.NotifyResult.Notify -> {
+                try {
+                    logRepository.info(
+                        "Notification triggered for item '${item.name}': ${result.message}",
+                    )
+                    notificationRepository.notify(result.message, item)
+                } catch (e: Exception) {
+                    logRepository.info("Unable to create a notification for '${item.name}' because: ${e.message}")
+                }
             }
+            is MonitorStrategy.NotifyResult.Skip ->
+                logRepository.info("No notification for '${item.name}': ${result.reason}")
+            null -> Unit
         }
     }
 }

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommand.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommand.kt
@@ -43,7 +43,7 @@ class ExecuteStrategyCommand(
                 }
             }
             is MonitorStrategy.NotifyResult.Skip ->
-                logRepository.debug("No notification for '${item.name}': ${result.reason}")
+                logRepository.debug("No notification for '${item.name}' using strategy '${strategy::class.simpleName}': ${result.reason}")
             null -> Unit
         }
     }

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommand.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommand.kt
@@ -43,7 +43,7 @@ class ExecuteStrategyCommand(
                 }
             }
             is MonitorStrategy.NotifyResult.Skip ->
-                logRepository.info("No notification for '${item.name}': ${result.reason}")
+                logRepository.debug("No notification for '${item.name}': ${result.reason}")
             null -> Unit
         }
     }

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MarketPriceComparisonStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MarketPriceComparisonStrategy.kt
@@ -9,10 +9,10 @@ class MarketPriceComparisonStrategy(
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,
-    ): String? {
+    ): MonitorStrategy.NotifyResult {
         // TODO: Implement market price comparison logic
-        // TODO: Returning null for now (no notification)
-        return null
+        // TODO: Returning Skip for now (no notification)
+        return MonitorStrategy.NotifyResult.Skip("Not implemented")
     }
 
     override fun requiresBaseline(): Boolean = false

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MonitorStrategy.kt
@@ -4,16 +4,28 @@ import com.cereal.command.monitor.models.Item
 
 interface MonitorStrategy {
     /**
+     * Sealed result type for [shouldNotify].
+     */
+    sealed class NotifyResult {
+        /** A notification should be sent with this [message]. */
+        data class Notify(val message: String) : NotifyResult()
+
+        /** No notification should be sent. [reason] describes why. */
+        data class Skip(val reason: String) : NotifyResult()
+    }
+
+    /**
      * Determines if a notification should be sent based on the current and previous state of the item.
      *
      * @param item The current state of the item to evaluate.
      * @param previousItem The previous state of the item, or null if unavailable (on first run).
-     * @return the message if a notification should be sent, null otherwise.
+     * @return [NotifyResult.Notify] with a message if a notification should be sent,
+     *         [NotifyResult.Skip] with a reason otherwise.
      */
     suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,
-    ): String?
+    ): NotifyResult
 
     /**
      * Indicates whether an initial baseline or previous item is required for the strategy to function correctly.

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableMonitorStrategy.kt
@@ -27,16 +27,16 @@ class NewItemAvailableMonitorStrategy(
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,
-    ): String? {
+    ): MonitorStrategy.NotifyResult {
         val isNewItem =
             item.getValue<ItemProperty.PublishDate>()?.value?.let {
                 it > since
             } ?: (previousItem == null)
 
         return if (isNewItem) {
-            "Found new item: ${item.name}."
+            MonitorStrategy.NotifyResult.Notify("Found new item: ${item.name}.")
         } else {
-            null
+            MonitorStrategy.NotifyResult.Skip("Not a new item")
         }
     }
 

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceChangedMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceChangedMonitorStrategy.kt
@@ -22,17 +22,20 @@ class PriceChangedMonitorStrategy : MonitorStrategy {
     ): MonitorStrategy.NotifyResult {
         if (previousItem == null) return MonitorStrategy.NotifyResult.Skip("No previous item")
 
-        val currentPrice = item.getValue<ItemProperty.Price>()
-            ?: return MonitorStrategy.NotifyResult.Skip("Price property missing on current item")
-        val previousPrice = previousItem.getValue<ItemProperty.Price>()
-            ?: return MonitorStrategy.NotifyResult.Skip("Price property missing on previous item")
+        val currentPrice =
+            item.getValue<ItemProperty.Price>()
+                ?: return MonitorStrategy.NotifyResult.Skip("Price property missing on current item")
+        val previousPrice =
+            previousItem.getValue<ItemProperty.Price>()
+                ?: return MonitorStrategy.NotifyResult.Skip("Price property missing on previous item")
 
         if (currentPrice.currency != previousPrice.currency) {
             return MonitorStrategy.NotifyResult.Skip("Currency mismatch")
         }
 
-        val stock = item.getValue<ItemProperty.Stock>()
-            ?: return MonitorStrategy.NotifyResult.Skip("Stock property missing")
+        val stock =
+            item.getValue<ItemProperty.Stock>()
+                ?: return MonitorStrategy.NotifyResult.Skip("Stock property missing")
         if (!stock.isInStock) return MonitorStrategy.NotifyResult.Skip("Item is not in stock")
 
         if (currentPrice.value.compareTo(previousPrice.value) == 0) {

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceChangedMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceChangedMonitorStrategy.kt
@@ -19,23 +19,32 @@ class PriceChangedMonitorStrategy : MonitorStrategy {
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,
-    ): String? {
-        if (previousItem == null) return null
+    ): MonitorStrategy.NotifyResult {
+        if (previousItem == null) return MonitorStrategy.NotifyResult.Skip("No previous item")
 
-        val currentPrice = item.getValue<ItemProperty.Price>() ?: return null
-        val previousPrice = previousItem.getValue<ItemProperty.Price>() ?: return null
+        val currentPrice = item.getValue<ItemProperty.Price>()
+            ?: return MonitorStrategy.NotifyResult.Skip("Price property missing on current item")
+        val previousPrice = previousItem.getValue<ItemProperty.Price>()
+            ?: return MonitorStrategy.NotifyResult.Skip("Price property missing on previous item")
 
-        if (currentPrice.currency != previousPrice.currency) return null
+        if (currentPrice.currency != previousPrice.currency) {
+            return MonitorStrategy.NotifyResult.Skip("Currency mismatch")
+        }
 
-        val stock = item.getValue<ItemProperty.Stock>() ?: return null
-        if (!stock.isInStock) return null
+        val stock = item.getValue<ItemProperty.Stock>()
+            ?: return MonitorStrategy.NotifyResult.Skip("Stock property missing")
+        if (!stock.isInStock) return MonitorStrategy.NotifyResult.Skip("Item is not in stock")
 
-        if (currentPrice.value.compareTo(previousPrice.value) == 0) return null
+        if (currentPrice.value.compareTo(previousPrice.value) == 0) {
+            return MonitorStrategy.NotifyResult.Skip("Price is unchanged")
+        }
 
         val direction = if (currentPrice.value < previousPrice.value) "↓" else "↑"
         val currency = currentPrice.currency.code
 
-        return "Price for ${item.name} changed: ${previousPrice.value} $currency → ${currentPrice.value} $currency ($direction)"
+        return MonitorStrategy.NotifyResult.Notify(
+            "Price for ${item.name} changed: ${previousPrice.value} $currency → ${currentPrice.value} $currency ($direction)",
+        )
     }
 
     override fun requiresBaseline(): Boolean = true

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceDropMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceDropMonitorStrategy.kt
@@ -22,7 +22,9 @@ class PriceDropMonitorStrategy : MonitorStrategy {
         if (previousItem == null) return MonitorStrategy.NotifyResult.Skip("No previous item")
 
         val price = item.getValue<ItemProperty.Price>()?.value ?: return MonitorStrategy.NotifyResult.Skip("No price")
-        val previousPrice = previousItem.getValue<ItemProperty.Price>()?.value ?: return MonitorStrategy.NotifyResult.Skip("No previous price")
+        val previousPrice =
+            previousItem.getValue<ItemProperty.Price>()?.value
+                ?: return MonitorStrategy.NotifyResult.Skip("No previous price")
 
         return if (previousPrice.compareTo(price) == 1) {
             MonitorStrategy.NotifyResult.Notify("Price for ${item.name} dropped to $price.")

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceDropMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceDropMonitorStrategy.kt
@@ -18,16 +18,16 @@ class PriceDropMonitorStrategy : MonitorStrategy {
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,
-    ): String? {
-        if (previousItem == null) return null
+    ): MonitorStrategy.NotifyResult {
+        if (previousItem == null) return MonitorStrategy.NotifyResult.Skip("No previous item")
 
-        val price = item.getValue<ItemProperty.Price>()?.value ?: return null
-        val previousPrice = previousItem.getValue<ItemProperty.Price>()?.value ?: return null
+        val price = item.getValue<ItemProperty.Price>()?.value ?: return MonitorStrategy.NotifyResult.Skip("No price")
+        val previousPrice = previousItem.getValue<ItemProperty.Price>()?.value ?: return MonitorStrategy.NotifyResult.Skip("No previous price")
 
         return if (previousPrice.compareTo(price) == 1) {
-            "Price for ${item.name} dropped to $price."
+            MonitorStrategy.NotifyResult.Notify("Price for ${item.name} dropped to $price.")
         } else {
-            null
+            MonitorStrategy.NotifyResult.Skip("Price did not drop")
         }
     }
 

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategy.kt
@@ -23,21 +23,23 @@ class StockAvailableMonitorStrategy(
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,
-    ): String? {
+    ): MonitorStrategy.NotifyResult {
         // Handle initial run case when notifyOnInitialRun is enabled
         if (notifyOnInitialRun && previousItem == null) {
-            return generateInitialRunMessage(item)
+            val msg = generateInitialRunMessage(item)
+            return if (msg != null) MonitorStrategy.NotifyResult.Notify(msg) else MonitorStrategy.NotifyResult.Skip("Not in stock on initial run")
         }
 
         // If notifyOnInitialRun is false and there's no previous item, don't notify
         if (!notifyOnInitialRun && previousItem == null) {
-            return null
+            return MonitorStrategy.NotifyResult.Skip("No previous item")
         }
 
         val availableStockMessage = generateAvailableStockMessage(item, previousItem)
-        if (availableStockMessage != null) return availableStockMessage
+        if (availableStockMessage != null) return MonitorStrategy.NotifyResult.Notify(availableStockMessage)
 
-        return generateVariantChangesMessage(item, previousItem)
+        val variantMsg = generateVariantChangesMessage(item, previousItem)
+        return if (variantMsg != null) MonitorStrategy.NotifyResult.Notify(variantMsg) else MonitorStrategy.NotifyResult.Skip("No stock changes")
     }
 
     private fun generateInitialRunMessage(item: Item): String? {

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategy.kt
@@ -27,7 +27,13 @@ class StockAvailableMonitorStrategy(
         // Handle initial run case when notifyOnInitialRun is enabled
         if (notifyOnInitialRun && previousItem == null) {
             val msg = generateInitialRunMessage(item)
-            return if (msg != null) MonitorStrategy.NotifyResult.Notify(msg) else MonitorStrategy.NotifyResult.Skip("Not in stock on initial run")
+            return if (msg != null) {
+                MonitorStrategy.NotifyResult.Notify(
+                    msg,
+                )
+            } else {
+                MonitorStrategy.NotifyResult.Skip("Not in stock on initial run")
+            }
         }
 
         // If notifyOnInitialRun is false and there's no previous item, don't notify
@@ -39,7 +45,13 @@ class StockAvailableMonitorStrategy(
         if (availableStockMessage != null) return MonitorStrategy.NotifyResult.Notify(availableStockMessage)
 
         val variantMsg = generateVariantChangesMessage(item, previousItem)
-        return if (variantMsg != null) MonitorStrategy.NotifyResult.Notify(variantMsg) else MonitorStrategy.NotifyResult.Skip("No stock changes")
+        return if (variantMsg != null) {
+            MonitorStrategy.NotifyResult.Notify(
+                variantMsg,
+            )
+        } else {
+            MonitorStrategy.NotifyResult.Skip("No stock changes")
+        }
     }
 
     private fun generateInitialRunMessage(item: Item): String? {

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockChangedMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockChangedMonitorStrategy.kt
@@ -25,7 +25,13 @@ class StockChangedMonitorStrategy : MonitorStrategy {
         if (stockMessage != null) return MonitorStrategy.NotifyResult.Notify(stockMessage)
 
         val variantMsg = generateVariantChangesMessage(item, previousItem)
-        return if (variantMsg != null) MonitorStrategy.NotifyResult.Notify(variantMsg) else MonitorStrategy.NotifyResult.Skip("No stock changes")
+        return if (variantMsg != null) {
+            MonitorStrategy.NotifyResult.Notify(
+                variantMsg,
+            )
+        } else {
+            MonitorStrategy.NotifyResult.Skip("No stock changes")
+        }
     }
 
     private fun generateStockChangeMessage(

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockChangedMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockChangedMonitorStrategy.kt
@@ -20,11 +20,12 @@ class StockChangedMonitorStrategy : MonitorStrategy {
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,
-    ): String? {
+    ): MonitorStrategy.NotifyResult {
         val stockMessage = generateStockChangeMessage(item, previousItem)
-        if (stockMessage != null) return stockMessage
+        if (stockMessage != null) return MonitorStrategy.NotifyResult.Notify(stockMessage)
 
-        return generateVariantChangesMessage(item, previousItem)
+        val variantMsg = generateVariantChangesMessage(item, previousItem)
+        return if (variantMsg != null) MonitorStrategy.NotifyResult.Notify(variantMsg) else MonitorStrategy.NotifyResult.Skip("No stock changes")
     }
 
     private fun generateStockChangeMessage(

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/EqualsOrBelowPriceCommandExecutionScriptStrategyTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/EqualsOrBelowPriceCommandExecutionScriptStrategyTest.kt
@@ -8,8 +8,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import java.math.BigDecimal
 import kotlin.test.Test
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import kotlin.test.assertIs
 
 class EqualsOrBelowPriceCommandExecutionScriptStrategyTest {
     @Test
@@ -25,7 +24,7 @@ class EqualsOrBelowPriceCommandExecutionScriptStrategyTest {
             val strategy = EqualsOrBelowPriceMonitorStrategy(BigDecimal("150.00"), Currency.USD)
             val result = strategy.shouldNotify(item, null)
 
-            assertNotNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Notify>(result)
             Unit
         }
 
@@ -42,7 +41,7 @@ class EqualsOrBelowPriceCommandExecutionScriptStrategyTest {
             val strategy = EqualsOrBelowPriceMonitorStrategy(BigDecimal("200.00"), Currency.USD)
             val result = strategy.shouldNotify(item, null)
 
-            assertNotNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Notify>(result)
             Unit
         }
 
@@ -79,7 +78,7 @@ class EqualsOrBelowPriceCommandExecutionScriptStrategyTest {
             val strategy = EqualsOrBelowPriceMonitorStrategy(BigDecimal("150.00"), Currency.USD)
             val result = strategy.shouldNotify(item, null)
 
-            assertNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Skip>(result)
         }
 
     @Test
@@ -104,7 +103,7 @@ class EqualsOrBelowPriceCommandExecutionScriptStrategyTest {
             strategy.shouldNotify(item1, null)
             val result = strategy.shouldNotify(item2, item1)
 
-            assertNotNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Notify>(result)
             Unit
         }
 }

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
@@ -72,6 +72,6 @@ class ExecuteStrategyCommandTest {
             executeStrategyCommand.execute()
 
             coVerify(exactly = 0) { notificationRepository.notify(any(), any()) }
-            coVerify { logRepository.debug("No notification for 'item': no reason") }
+            coVerify { logRepository.debug(match { it.startsWith("No notification for 'item'") && it.contains("no reason") }) }
         }
 }

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
@@ -65,12 +65,13 @@ class ExecuteStrategyCommandTest {
             val item = Item("TestItem", "url", "item", properties = emptyList())
 
             coEvery { strategy.shouldNotify(item, any()) } returns MonitorStrategy.NotifyResult.Skip("no reason")
+            coJustRun { logRepository.info(any()) }
 
             executeStrategyCommand =
                 ExecuteStrategyCommand(notificationRepository, logRepository, strategy, item, null)
             executeStrategyCommand.execute()
 
             coVerify(exactly = 0) { notificationRepository.notify(any(), any()) }
-            coVerify(exactly = 0) { logRepository.info("Sending notification for 'TestItem'.") }
+            coVerify { logRepository.info("No notification for 'item': no reason") }
         }
 }

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
@@ -65,13 +65,13 @@ class ExecuteStrategyCommandTest {
             val item = Item("TestItem", "url", "item", properties = emptyList())
 
             coEvery { strategy.shouldNotify(item, any()) } returns MonitorStrategy.NotifyResult.Skip("no reason")
-            coJustRun { logRepository.info(any()) }
+            coJustRun { logRepository.debug(any()) }
 
             executeStrategyCommand =
                 ExecuteStrategyCommand(notificationRepository, logRepository, strategy, item, null)
             executeStrategyCommand.execute()
 
             coVerify(exactly = 0) { notificationRepository.notify(any(), any()) }
-            coVerify { logRepository.info("No notification for 'item': no reason") }
+            coVerify { logRepository.debug("No notification for 'item': no reason") }
         }
 }

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
@@ -30,7 +30,7 @@ class ExecuteStrategyCommandTest {
             val item = Item("1", "url", "TestItem", properties = emptyList())
             val message = "Notify Message"
 
-            coEvery { strategy.shouldNotify(item, any()) } returns message
+            coEvery { strategy.shouldNotify(item, any()) } returns MonitorStrategy.NotifyResult.Notify(message)
             coJustRun { notificationRepository.notify(message, item) }
             coJustRun { logRepository.info(any()) }
 
@@ -48,7 +48,7 @@ class ExecuteStrategyCommandTest {
             val message = "Notify Message"
             val exceptionMessage = "Notification Exception"
 
-            coEvery { strategy.shouldNotify(item, any()) } returns message
+            coEvery { strategy.shouldNotify(item, any()) } returns MonitorStrategy.NotifyResult.Notify(message)
             coEvery { notificationRepository.notify(any(), any()) } throws RuntimeException(exceptionMessage)
             coJustRun { logRepository.info(any()) }
 
@@ -64,7 +64,7 @@ class ExecuteStrategyCommandTest {
         runBlocking {
             val item = Item("TestItem", "url", "item", properties = emptyList())
 
-            coEvery { strategy.shouldNotify(item, any()) } returns null
+            coEvery { strategy.shouldNotify(item, any()) } returns MonitorStrategy.NotifyResult.Skip("no reason")
 
             executeStrategyCommand =
                 ExecuteStrategyCommand(notificationRepository, logRepository, strategy, item, null)

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableCommandExecutionScriptStrategyTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableCommandExecutionScriptStrategyTest.kt
@@ -4,8 +4,7 @@ import com.cereal.command.monitor.models.Item
 import com.cereal.command.monitor.models.ItemProperty
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import kotlin.test.assertIs
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -25,7 +24,7 @@ class NewItemAvailableCommandExecutionScriptStrategyTest {
 
         val result = runBlocking { strategy.shouldNotify(item, null) }
 
-        assertNotNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Notify>(result)
     }
 
     @Test
@@ -42,7 +41,7 @@ class NewItemAvailableCommandExecutionScriptStrategyTest {
 
         val result = runBlocking { strategy.shouldNotify(item, null) }
 
-        assertNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result)
     }
 
     @Test
@@ -54,7 +53,7 @@ class NewItemAvailableCommandExecutionScriptStrategyTest {
 
         val result = runBlocking { strategy.shouldNotify(item, previousItem) }
 
-        assertNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result)
     }
 
     @Test
@@ -79,8 +78,8 @@ class NewItemAvailableCommandExecutionScriptStrategyTest {
         val result1 = runBlocking { strategy.shouldNotify(item, null) }
         val result2 = runBlocking { strategy.shouldNotify(item, previousItem) }
 
-        assertNotNull(result1)
-        assertNull(result2)
+        assertIs<MonitorStrategy.NotifyResult.Notify>(result1)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result2)
     }
 
     @Test
@@ -105,8 +104,8 @@ class NewItemAvailableCommandExecutionScriptStrategyTest {
         val result1 = runBlocking { strategy.shouldNotify(item1, null) }
         val result2 = runBlocking { strategy.shouldNotify(item2, null) }
 
-        assertNotNull(result1)
-        assertNotNull(result2)
+        assertIs<MonitorStrategy.NotifyResult.Notify>(result1)
+        assertIs<MonitorStrategy.NotifyResult.Notify>(result2)
     }
 
     @Test
@@ -117,6 +116,6 @@ class NewItemAvailableCommandExecutionScriptStrategyTest {
 
         val result = runBlocking { strategy.shouldNotify(item, null) }
 
-        assertNotNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Notify>(result)
     }
 }

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/PriceChangedMonitorStrategyTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/PriceChangedMonitorStrategyTest.kt
@@ -7,9 +7,7 @@ import kotlinx.coroutines.runBlocking
 import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import kotlin.test.assertIs
 
 class PriceChangedMonitorStrategyTest {
     private val subject = PriceChangedMonitorStrategy()
@@ -41,28 +39,28 @@ class PriceChangedMonitorStrategyTest {
     )
 
     @Test
-    fun `returns null when previousItem is null`() =
+    fun `returns Skip when previousItem is null`() =
         runBlocking {
             val current = itemWithPriceAndStock(BigDecimal("3.99"))
-            assertNull(subject.shouldNotify(current, null))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(current, null))
         }
 
     @Test
-    fun `returns null when price is unchanged`() =
+    fun `returns Skip when price is unchanged`() =
         runBlocking {
             val item = itemWithPriceAndStock(BigDecimal("3.99"))
-            assertNull(subject.shouldNotify(item, item))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(item, item))
         }
 
     @Test
-    fun `returns message with down arrow when price decreases while in stock`() =
+    fun `returns Notify with down arrow when price decreases while in stock`() =
         runBlocking {
             val current = itemWithPriceAndStock(BigDecimal("2.99"))
             val previous = itemWithPriceAndStock(BigDecimal("3.99"))
             val result = subject.shouldNotify(current, previous)
-            assertNotNull(result)
-            assertTrue(result.contains("↓"), "Expected ↓ in message: $result")
-            assertTrue(result.contains("Spar"), "Expected item name in message: $result")
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assert(notify.message.contains("↓")) { "Expected ↓ in message: ${notify.message}" }
+            assert(notify.message.contains("Spar")) { "Expected item name in message: ${notify.message}" }
         }
 
     @Test
@@ -71,30 +69,31 @@ class PriceChangedMonitorStrategyTest {
             val current = itemWithPriceAndStock(BigDecimal("2.99"))
             val previous = itemWithPriceAndStock(BigDecimal("3.99"))
             val result = subject.shouldNotify(current, previous)
-            assertEquals("Price for Spar changed: 3.99 EUR → 2.99 EUR (↓)", result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals("Price for Spar changed: 3.99 EUR → 2.99 EUR (↓)", notify.message)
         }
 
     @Test
-    fun `returns message with up arrow when price increases while in stock`() =
+    fun `returns Notify with up arrow when price increases while in stock`() =
         runBlocking {
             val current = itemWithPriceAndStock(BigDecimal("4.99"))
             val previous = itemWithPriceAndStock(BigDecimal("3.99"))
             val result = subject.shouldNotify(current, previous)
-            assertNotNull(result)
-            assertTrue(result.contains("↑"), "Expected ↑ in message: $result")
-            assertTrue(result.contains("Spar"), "Expected item name in message: $result")
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assert(notify.message.contains("↑")) { "Expected ↑ in message: ${notify.message}" }
+            assert(notify.message.contains("Spar")) { "Expected item name in message: ${notify.message}" }
         }
 
     @Test
-    fun `returns null when price changes but item is out of stock`() =
+    fun `returns Skip when price changes but item is out of stock`() =
         runBlocking {
             val current = itemWithPriceAndStock(BigDecimal("2.99"), isInStock = false, amount = 0)
             val previous = itemWithPriceAndStock(BigDecimal("3.99"))
-            assertNull(subject.shouldNotify(current, previous))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(current, previous))
         }
 
     @Test
-    fun `returns null when current item has no price`() =
+    fun `returns Skip when current item has no price`() =
         runBlocking {
             val current =
                 Item(
@@ -104,11 +103,11 @@ class PriceChangedMonitorStrategyTest {
                     properties = listOf(ItemProperty.Stock(isInStock = true, amount = 3, level = null)),
                 )
             val previous = itemWithPriceAndStock(BigDecimal("3.99"))
-            assertNull(subject.shouldNotify(current, previous))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(current, previous))
         }
 
     @Test
-    fun `returns null when previous item has no price`() =
+    fun `returns Skip when previous item has no price`() =
         runBlocking {
             val current = itemWithPriceAndStock(BigDecimal("2.99"))
             val previous =
@@ -118,19 +117,19 @@ class PriceChangedMonitorStrategyTest {
                     name = "Spar",
                     properties = listOf(ItemProperty.Stock(isInStock = true, amount = 3, level = null)),
                 )
-            assertNull(subject.shouldNotify(current, previous))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(current, previous))
         }
 
     @Test
-    fun `returns null when current item has no stock property`() =
+    fun `returns Skip when current item has no stock property`() =
         runBlocking {
             val current = itemWithPriceOnly(BigDecimal("2.99"))
             val previous = itemWithPriceAndStock(BigDecimal("3.99"))
-            assertNull(subject.shouldNotify(current, previous))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(current, previous))
         }
 
     @Test
-    fun `returns null when currencies differ between current and previous`() =
+    fun `returns Skip when currencies differ between current and previous`() =
         runBlocking {
             val current = itemWithPriceAndStock(BigDecimal("2.99"), currency = Currency.EUR)
             val previous =
@@ -144,16 +143,15 @@ class PriceChangedMonitorStrategyTest {
                             ItemProperty.Stock(isInStock = true, amount = 3, level = null),
                         ),
                 )
-            assertNull(subject.shouldNotify(current, previous))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(current, previous))
         }
 
     @Test
-    fun `returns notification when previous item has no stock property but current item is in stock and price changed`() =
+    fun `returns Notify when previous item has no stock property but current item is in stock and price changed`() =
         runBlocking {
             val current = itemWithPriceAndStock(BigDecimal("2.99"))
             val previous = itemWithPriceOnly(BigDecimal("3.99"))
-            val result = subject.shouldNotify(current, previous)
-            assertNotNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Notify>(subject.shouldNotify(current, previous))
         }
 
     @Test
@@ -162,11 +160,12 @@ class PriceChangedMonitorStrategyTest {
             val current = itemWithPriceAndStock(BigDecimal("3.99"))
             val previous = itemWithPriceAndStock(BigDecimal("2.99"))
             val result = subject.shouldNotify(current, previous)
-            assertEquals("Price for Spar changed: 2.99 EUR → 3.99 EUR (↑)", result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals("Price for Spar changed: 2.99 EUR → 3.99 EUR (↑)", notify.message)
         }
 
     @Test
     fun `requiresBaseline returns true`() {
-        assertTrue(subject.requiresBaseline())
+        assert(subject.requiresBaseline())
     }
 }

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/PriceDropCommandExecutionScriptStrategyTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/PriceDropCommandExecutionScriptStrategyTest.kt
@@ -4,10 +4,9 @@ import com.cereal.command.monitor.models.Currency
 import com.cereal.command.monitor.models.Item
 import com.cereal.command.monitor.models.ItemProperty
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.Assertions.assertNull
 import java.math.BigDecimal
 import kotlin.test.Test
-import kotlin.test.assertNotNull
+import kotlin.test.assertIs
 
 class PriceDropCommandExecutionScriptStrategyTest {
     private val subject = PriceDropMonitorStrategy()
@@ -21,9 +20,9 @@ class PriceDropCommandExecutionScriptStrategyTest {
             val previousItem = Item("1", "url", "item", properties = listOf(previousPrice))
 
             // First call to shouldNotify should return false as there is no previous price to check against
-            assertNull(subject.shouldNotify(item, null))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(item, null))
             // Second call with the same price should return false as price has not dropped
-            assertNull(subject.shouldNotify(item, previousItem))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(item, previousItem))
         }
 
     @Test
@@ -34,13 +33,13 @@ class PriceDropCommandExecutionScriptStrategyTest {
             val previousItem = Item("1", "url", "item", properties = listOf(initialPrice))
 
             // initialize item with original price
-            assertNull(subject.shouldNotify(item1, previousItem))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(item1, previousItem))
 
             val previousPrice = ItemProperty.Price(BigDecimal(150), Currency.USD)
             val item2 = Item("1", "url", "item", properties = listOf(previousPrice))
 
             // after price decrease shouldNotify should return true
-            assertNotNull(subject.shouldNotify(item1, item2))
+            assertIs<MonitorStrategy.NotifyResult.Notify>(subject.shouldNotify(item1, item2))
             Unit
         }
 
@@ -52,12 +51,12 @@ class PriceDropCommandExecutionScriptStrategyTest {
             val previousItem = Item("1", "url", "item", properties = listOf(initialPrice))
 
             // initialize item with original price
-            assertNull(subject.shouldNotify(item1, previousItem))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(item1, previousItem))
 
             val increasedPrice = ItemProperty.Price(BigDecimal(150), Currency.USD)
             val item2 = Item("1", "url", "item", properties = listOf(increasedPrice))
 
             // after price increase shouldNotify should return false
-            assertNull(subject.shouldNotify(item2, item1))
+            assertIs<MonitorStrategy.NotifyResult.Skip>(subject.shouldNotify(item2, item1))
         }
 }

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategyTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategyTest.kt
@@ -6,8 +6,7 @@ import com.cereal.command.monitor.models.Variant
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import kotlin.test.assertIs
 
 class StockAvailableMonitorStrategyTest {
     private val monitorStrategy = StockAvailableMonitorStrategy()
@@ -31,7 +30,7 @@ class StockAvailableMonitorStrategyTest {
             )
         val result = runBlocking { monitorStrategy.shouldNotify(item, previousItem) }
 
-        assertNotNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Notify>(result)
     }
 
     @Test
@@ -52,7 +51,7 @@ class StockAvailableMonitorStrategyTest {
             )
         val result = runBlocking { monitorStrategy.shouldNotify(item, previousItem) }
 
-        assertNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result)
     }
 
     @Test
@@ -74,7 +73,7 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategy.shouldNotify(currentItem, previousItem) }
 
-        assertEquals("Test Item is in stock (5)!", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("Test Item is in stock (5)!"), result)
     }
 
     @Test
@@ -96,7 +95,7 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategy.shouldNotify(currentItem, previousItem) }
 
-        assertNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result)
     }
 
     @Test
@@ -140,7 +139,7 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategy.shouldNotify(currentItem, previousItem) }
 
-        assertEquals("New variant variant2 is in stock: HIGH", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("New variant variant2 is in stock: HIGH"), result)
     }
 
     @Test
@@ -178,7 +177,7 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategy.shouldNotify(currentItem, previousItem) }
 
-        assertEquals("Variant variant1 is in stock: HIGH", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("Variant variant1 is in stock: HIGH"), result)
     }
 
     @Test
@@ -216,7 +215,7 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategy.shouldNotify(currentItem, previousItem) }
 
-        assertNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result)
     }
 
     // Tests for initial run notification functionality
@@ -233,7 +232,7 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
-        assertEquals("Test Item is in stock (5)!", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("Test Item is in stock (5)!"), result)
     }
 
     @Test
@@ -248,7 +247,7 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
-        assertNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result)
     }
 
     @Test
@@ -278,7 +277,7 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
-        assertEquals("Variant Size M is in stock: 3\nVariant Size L is in stock: HIGH", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("Variant Size M is in stock: 3\nVariant Size L is in stock: HIGH"), result)
     }
 
     @Test
@@ -302,14 +301,11 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
-        assertNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result)
     }
 
     @Test
     fun `should not notify on initial run with default strategy (backwards compatibility)`() {
-        // This test verifies that the default strategy requires a baseline
-        // In practice, the monitoring system won't call shouldNotify with null previousItem
-        // for strategies that require baseline, but we test the behavior directly here
         val item =
             Item(
                 id = "1",
@@ -318,12 +314,9 @@ class StockAvailableMonitorStrategyTest {
                 properties = listOf(ItemProperty.Stock(isInStock = true, amount = 5, "HIGH")),
             )
 
-        // The default strategy should not notify on initial run even if called directly
-        // This is a defensive test - in practice this won't happen due to requiresBaseline check
         val result = runBlocking { monitorStrategy.shouldNotify(item, null) }
 
-        // The strategy should return null because it doesn't have notifyOnInitialRun enabled
-        assertNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result)
     }
 
     @Test
@@ -358,7 +351,7 @@ class StockAvailableMonitorStrategyTest {
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(item, null) }
 
         // Should prioritize item-level notification over variant notifications
-        assertEquals("Test Item is in stock (2)!", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("Test Item is in stock (2)!"), result)
     }
 
     @Test
@@ -380,6 +373,6 @@ class StockAvailableMonitorStrategyTest {
 
         val result = runBlocking { monitorStrategyWithInitialRun.shouldNotify(currentItem, previousItem) }
 
-        assertEquals("Test Item is in stock (5)!", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("Test Item is in stock (5)!"), result)
     }
 }

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/StockChangedMonitorStrategyTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/StockChangedMonitorStrategyTest.kt
@@ -6,7 +6,7 @@ import com.cereal.command.monitor.models.Variant
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import kotlin.test.assertIs
 
 class StockChangedMonitorStrategyTest {
     private val strategy = StockChangedMonitorStrategy()
@@ -30,7 +30,7 @@ class StockChangedMonitorStrategyTest {
 
         val result = runBlocking { strategy.shouldNotify(current, previous) }
 
-        assertEquals("Item A is now in stock (3)!", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("Item A is now in stock (3)!"), result)
     }
 
     @Test
@@ -52,7 +52,7 @@ class StockChangedMonitorStrategyTest {
 
         val result = runBlocking { strategy.shouldNotify(current, previous) }
 
-        assertEquals("Item A is now out of stock", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("Item A is now out of stock"), result)
     }
 
     @Test
@@ -74,7 +74,7 @@ class StockChangedMonitorStrategyTest {
 
         val result = runBlocking { strategy.shouldNotify(current, previous) }
 
-        assertEquals("Item A stock level changed: 2 → 5", result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify("Item A stock level changed: 2 → 5"), result)
     }
 
     @Test
@@ -96,7 +96,7 @@ class StockChangedMonitorStrategyTest {
 
         val result = runBlocking { strategy.shouldNotify(current, previous) }
 
-        assertNull(result)
+        assertIs<MonitorStrategy.NotifyResult.Skip>(result)
     }
 
     @Test
@@ -152,7 +152,7 @@ class StockChangedMonitorStrategyTest {
             Variant Size 9 stock level changed: 2 → 5
             """.trimIndent()
 
-        assertEquals(expected, result)
+        assertEquals(MonitorStrategy.NotifyResult.Notify(expected), result)
     }
 
     @Test

--- a/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
+++ b/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
@@ -14,13 +14,16 @@ class FilteredNewItemMonitorStrategy(
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,
-    ): String? {
+    ): MonitorStrategy.NotifyResult {
         // Delegate baseline newness check
-        val baselineMessage = baselineStrategy.shouldNotify(item, previousItem) ?: return null
+        val baselineResult = baselineStrategy.shouldNotify(item, previousItem)
+        if (baselineResult is MonitorStrategy.NotifyResult.Skip) return baselineResult
+
+        val baselineMessage = (baselineResult as MonitorStrategy.NotifyResult.Notify).message
 
         // If no filters configured, behave identically to original
         if (keywords.isEmpty() && authors.isEmpty() && categories.isEmpty()) {
-            return baselineMessage
+            return MonitorStrategy.NotifyResult.Notify(baselineMessage)
         }
 
         val matchesKeyword =
@@ -52,7 +55,11 @@ class FilteredNewItemMonitorStrategy(
 
         val passed = matchesKeyword || matchesAuthor || matchesCategory
 
-        return if (passed) baselineMessage else null
+        return if (passed) {
+            MonitorStrategy.NotifyResult.Notify(baselineMessage)
+        } else {
+            MonitorStrategy.NotifyResult.Skip("Item did not match any configured keywords, authors, or categories")
+        }
     }
 
     override fun requiresBaseline(): Boolean = baselineStrategy.requiresBaseline()

--- a/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
+++ b/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
@@ -15,11 +15,11 @@ class FilteredNewItemMonitorStrategy(
         item: Item,
         previousItem: Item?,
     ): MonitorStrategy.NotifyResult {
-        // Delegate baseline newness check
-        val baselineResult = baselineStrategy.shouldNotify(item, previousItem)
-        if (baselineResult is MonitorStrategy.NotifyResult.Skip) return baselineResult
-
-        val baselineMessage = (baselineResult as MonitorStrategy.NotifyResult.Notify).message
+        // Delegate baseline newness check; propagate Skip directly
+        val baselineMessage = when (val baselineResult = baselineStrategy.shouldNotify(item, previousItem)) {
+            is MonitorStrategy.NotifyResult.Skip -> return baselineResult
+            is MonitorStrategy.NotifyResult.Notify -> baselineResult.message
+        }
 
         // If no filters configured, behave identically to original
         if (keywords.isEmpty() && authors.isEmpty() && categories.isEmpty()) {

--- a/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
+++ b/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
@@ -16,10 +16,11 @@ class FilteredNewItemMonitorStrategy(
         previousItem: Item?,
     ): MonitorStrategy.NotifyResult {
         // Delegate baseline newness check; propagate Skip directly
-        val baselineMessage = when (val baselineResult = baselineStrategy.shouldNotify(item, previousItem)) {
-            is MonitorStrategy.NotifyResult.Skip -> return baselineResult
-            is MonitorStrategy.NotifyResult.Notify -> baselineResult.message
-        }
+        val baselineMessage =
+            when (val baselineResult = baselineStrategy.shouldNotify(item, previousItem)) {
+                is MonitorStrategy.NotifyResult.Skip -> return baselineResult
+                is MonitorStrategy.NotifyResult.Notify -> baselineResult.message
+            }
 
         // If no filters configured, behave identically to original
         if (keywords.isEmpty() && authors.isEmpty() && categories.isEmpty()) {

--- a/script-rss/src/test/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategyTest.kt
+++ b/script-rss/src/test/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategyTest.kt
@@ -10,7 +10,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import kotlin.test.assertIs
 
 class FilteredNewItemMonitorStrategyTest {
     private val baselineStrategy: MonitorStrategy = mockk()
@@ -34,7 +34,7 @@ class FilteredNewItemMonitorStrategyTest {
     fun `no filters configured passes through baseline message`() =
         runTest {
             val item = newItem()
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -45,16 +45,17 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
-    // --- Baseline returns null ---
+    // --- Baseline returns Skip ---
 
     @Test
-    fun `baseline returns null always returns null regardless of filters`() =
+    fun `baseline returns skip always returns skip regardless of filters`() =
         runTest {
             val item = newItem(name = "Kotlin Tutorial", author = "Alice", categories = listOf("tech"))
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns null
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Skip("no match")
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -65,7 +66,7 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Skip>(result)
         }
 
     // --- Keyword matches ---
@@ -74,7 +75,7 @@ class FilteredNewItemMonitorStrategyTest {
     fun `keyword matches returns baseline message`() =
         runTest {
             val item = newItem(name = "Kotlin Tutorial")
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -85,7 +86,8 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     // --- Author matches ---
@@ -94,7 +96,7 @@ class FilteredNewItemMonitorStrategyTest {
     fun `author matches returns baseline message`() =
         runTest {
             val item = newItem(name = "Some Post", author = "Alice")
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -105,7 +107,8 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     // --- Category matches ---
@@ -114,7 +117,7 @@ class FilteredNewItemMonitorStrategyTest {
     fun `category matches returns baseline message`() =
         runTest {
             val item = newItem(name = "Some Post", categories = listOf("tech"))
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -125,16 +128,17 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     // --- Nothing matches ---
 
     @Test
-    fun `nothing matches returns null`() =
+    fun `nothing matches returns skip`() =
         runTest {
             val item = newItem(name = "Java Tutorial", author = "Bob", categories = listOf("general"))
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -145,7 +149,7 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Skip>(result)
         }
 
     // --- Only keywords configured ---
@@ -154,7 +158,7 @@ class FilteredNewItemMonitorStrategyTest {
     fun `only keywords configured keyword matches returns baseline message`() =
         runTest {
             val item = newItem(name = "Kotlin Tutorial")
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -165,14 +169,15 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     @Test
-    fun `only keywords configured keyword does not match returns null`() =
+    fun `only keywords configured keyword does not match returns skip`() =
         runTest {
             val item = newItem(name = "Java Tutorial")
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -183,7 +188,7 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Skip>(result)
         }
 
     // --- Case-insensitive matching ---
@@ -192,7 +197,7 @@ class FilteredNewItemMonitorStrategyTest {
     fun `keyword matching is case-insensitive`() =
         runTest {
             val item = newItem(name = "KOTLIN tutorial")
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -203,14 +208,15 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     @Test
     fun `keyword matching in description is case-insensitive`() =
         runTest {
             val item = newItem(name = "Some Post", description = "KOTLIN programming")
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -221,14 +227,15 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     @Test
     fun `author matching is case-insensitive`() =
         runTest {
             val item = newItem(name = "Some Post", author = "ALICE")
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -239,14 +246,15 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     @Test
     fun `category matching is case-insensitive`() =
         runTest {
             val item = newItem(name = "Some Post", categories = listOf("TECH"))
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -257,7 +265,8 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     // --- Only authors configured ---
@@ -266,7 +275,7 @@ class FilteredNewItemMonitorStrategyTest {
     fun `only authors configured author matches returns baseline message`() =
         runTest {
             val item = newItem(author = "Jane Doe")
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -277,14 +286,15 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     @Test
-    fun `only authors configured author does not match returns null`() =
+    fun `only authors configured author does not match returns skip`() =
         runTest {
             val item = newItem(author = "Other Author")
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -295,7 +305,7 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Skip>(result)
         }
 
     // --- Only categories configured ---
@@ -304,7 +314,7 @@ class FilteredNewItemMonitorStrategyTest {
     fun `only categories configured category matches returns baseline message`() =
         runTest {
             val item = newItem(categories = listOf("tech"))
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -315,14 +325,15 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertEquals(baselineMessage, result)
+            val notify = assertIs<MonitorStrategy.NotifyResult.Notify>(result)
+            assertEquals(baselineMessage, notify.message)
         }
 
     @Test
-    fun `only categories configured category does not match returns null`() =
+    fun `only categories configured category does not match returns skip`() =
         runTest {
             val item = newItem(categories = listOf("sports"))
-            coEvery { baselineStrategy.shouldNotify(item, null) } returns baselineMessage
+            coEvery { baselineStrategy.shouldNotify(item, null) } returns MonitorStrategy.NotifyResult.Notify(baselineMessage)
 
             val strategy =
                 FilteredNewItemMonitorStrategy(
@@ -333,7 +344,7 @@ class FilteredNewItemMonitorStrategyTest {
                 )
 
             val result = strategy.shouldNotify(item, null)
-            assertNull(result)
+            assertIs<MonitorStrategy.NotifyResult.Skip>(result)
         }
 
     // --- requiresBaseline delegates ---


### PR DESCRIPTION
## refactor: replace `String?` return with `NotifyResult` sealed class on `MonitorStrategy`

### Motivation

`shouldNotify` returned `null` to mean "don't notify." Silent skips were invisible in logs — there was no way to see *why* a strategy decided not to fire.

### Changes

**Core contract**
- `MonitorStrategy.NotifyResult` sealed class added as a nested type with two subtypes:
  - `Notify(message: String)` — send a notification
  - `Skip(reason: String)` — do not notify; reason is logged

**Caller**
- `ExecuteStrategyCommand` — exhaustive `when` on `NotifyResult`; `Skip` logs: `No notification for '<name>': <reason>`

**Strategies updated**
- `PriceChangedMonitorStrategy`
- `NewItemAvailableMonitorStrategy`
- `StockAvailableMonitorStrategy`
- `StockChangedMonitorStrategy`
- `MarketPriceComparisonStrategy`
- `PriceDropMonitorStrategy`
- `EqualsOrBelowPriceMonitorStrategy`
- `FilteredNewItemMonitorStrategy` — also refactored to use a `when` expression on the baseline result, removing an unsafe cast

**Tests**
- All test files updated; `assertNull`/`assertNotNull` replaced with `assertIs<NotifyResult.Notify>` / `assertIs<NotifyResult.Skip>`
- 111 tests, 0 failures

### No behaviour change

Notification sending logic is unchanged. The only observable difference is additional log output when a strategy skips.