### PR TITLE
Prevent rental script startup notification spam

### DIFF
--- a/script-rental/src/main/kotlin/com/cereal/rental/RentalScript.kt
+++ b/script-rental/src/main/kotlin/com/cereal/rental/RentalScript.kt
@@ -54,7 +54,8 @@ class RentalScript : Script<RentalConfiguration> {
         val cities = parseCities(configuration.cities())
         val furnishing = configuration.furnishing()
         val propertyType = configuration.propertyType()
-        val strategy = MonitorStrategyFactory.newItemAvailableMonitorStrategy(Clock.System.now(), requiresBaseline = false)
+        val strategy =
+            MonitorStrategyFactory.newItemAvailableMonitorStrategy(Clock.System.now(), requiresBaseline = true)
         val strategies = listOf(strategy)
 
         val filters =
@@ -100,5 +101,6 @@ class RentalScript : Script<RentalConfiguration> {
         )
     }
 
-    private fun parseCities(input: String): List<String> = input.split(",").map { it.trim().lowercase() }.filter { it.isNotBlank() }
+    private fun parseCities(input: String): List<String> =
+        input.split(",").map { it.trim().lowercase() }.filter { it.isNotBlank() }
 }

--- a/script-rental/src/main/kotlin/com/cereal/rental/RentalScript.kt
+++ b/script-rental/src/main/kotlin/com/cereal/rental/RentalScript.kt
@@ -101,6 +101,5 @@ class RentalScript : Script<RentalConfiguration> {
         )
     }
 
-    private fun parseCities(input: String): List<String> =
-        input.split(",").map { it.trim().lowercase() }.filter { it.isNotBlank() }
+    private fun parseCities(input: String): List<String> = input.split(",").map { it.trim().lowercase() }.filter { it.isNotBlank() }
 }


### PR DESCRIPTION
## Summary
- Flip `requiresBaseline` to `true` for the rental script's item-available monitor strategy so the first run establishes a baseline of existing listings instead of treating every current listing as newly available.

## Why
On startup, the previous behavior (`requiresBaseline = false`) caused every existing rental listing to be reported as new, spamming notifications. With baselining enabled, only listings that appear *after* the first scan are reported.

## Test plan
- [ ] Run the rental script against a configured city — verify no notifications fire on the initial scan.
- [ ] Confirm a newly-added listing on a subsequent scan still triggers a notification.