### PR TITLE
fix(ci): allow Chrome sandbox on Ubuntu 24.04 in nightly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,5 +19,10 @@ jobs:
           cache: 'gradle'
       - name: Make gradlew executable
         run: chmod +x ./gradlew
+      - name: Allow Chrome sandbox on Ubuntu 24.04
+        # Ubuntu 24.04 restricts unprivileged user namespaces via AppArmor, which
+        # breaks Chrome's sandbox when kdriver launches it as the non-root runner
+        # user, causing FailedToConnectToBrowserException. Relax the restriction.
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Test
         run: ./gradlew integrationTest


### PR DESCRIPTION
## Summary
- The nightly `integrationTest` job failed every night with `FailedToConnectToBrowserException` (`DefaultBrowser.kt:198`) for the browser-based Funda/Pararius scrapers.
- Root cause: `ubuntu-latest` is now Ubuntu 24.04, which enables `kernel.apparmor_restrict_unprivileged_userns=1`. Since the runner is non-root, kdriver does not auto-disable Chrome's sandbox, and the AppArmor restriction blocks the sandbox from creating user namespaces — the renderer crashes before kdriver can connect.
- Fix: relax the AppArmor restriction before the test run so Chrome launches reliably with its sandbox intact. CI-only change, no production browser-security behavior touched.

## Note
These tests still hit live Funda/Pararius sites and assert non-empty results, so they can still fail if those sites change or return nothing — separate from the connection error fixed here.

If this scraper also runs in production as a non-root user on Ubuntu 24.04, consider passing `sandbox = false` to `createBrowser` in `BrowserBasedItemRepository` for a more portable fix.

## Test plan
- [ ] Trigger the nightly workflow (or `workflow_dispatch`) and confirm the integration tests connect to Chrome and run.