### PR TITLE
Tech-debt Phase 1: CI coverage, Dependabot, safer token unwrap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx*"
+      ktor:
+        patterns:
+          - "io.ktor*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        module: [ script-nike, script-snkrs, script-bdga-store, script-tgtg ]
+        module: [ script-nike, script-snkrs, script-bdga-store, script-tgtg, script-zalando, script-rss, script-rental, script-sample ]
 
     steps:
       - uses: actions/checkout@v6

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/stockx/OAuthTokenProvider.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/stockx/OAuthTokenProvider.kt
@@ -60,7 +60,7 @@ class OAuthTokenProvider(
             refreshToken = tokenData.refresh_token
             expiresAt = System.currentTimeMillis() + (tokenData.expires_in * 1000)
 
-            currentToken!!
+            requireNotNull(currentToken) { "Access token was unexpectedly null after authorization code exchange" }
         }
 
     suspend fun refreshToken(): String? =
@@ -92,7 +92,7 @@ class OAuthTokenProvider(
             refreshToken = tokenData.refresh_token
             expiresAt = System.currentTimeMillis() + (tokenData.expires_in * 1000)
 
-            currentToken!!
+            requireNotNull(currentToken) { "Access token was unexpectedly null after token refresh" }
         }
 
     suspend fun getToken(): String? {


### PR DESCRIPTION
Low-risk, self-contained quick wins from a technical-debt audit. Each item is independently shippable.

## Changes

### 1. CI builds all 8 script modules (was 4) — `build.yml`
The build matrix only covered `script-nike`, `script-snkrs`, `script-bdga-store`, `script-tgtg`. The other four (`script-sample`, `script-zalando`, `script-rss`, `script-rental`) are buildable modules that depend on `command-monitoring`, but were **never compiled or release-tested in CI** — a refactor in shared code could break them silently and still pass every check. Matrix now covers all 8.

### 2. Add Dependabot — `.github/dependabot.yml`
No automated dependency or CVE alerting existed. Adds weekly **Gradle** updates (Kotlin and Ktor grouped to reduce PR noise) and weekly **GitHub Actions** updates.

### 3. Safer token unwrap — `OAuthTokenProvider`
Replaced two `currentToken!!` non-null assertions with `requireNotNull(...) { "…" }` carrying descriptive messages, so a null token surfaces a clear error instead of a bare NPE.

## Verification
- `:command-monitoring:compileKotlin` + `ktlintMainSourceSetCheck` → clean
- All four newly-added modules `compileKotlin` → pass (none were broken)
- `:script-sample:scriptJar` → full ProGuard/obfuscation pipeline produced `release.jar` (this CI path was never exercised for these modules before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)