### PR TITLE
fix: skip run instead of crashing when browser fails to start

### DIFF
--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/rental/BrowserBasedItemRepository.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/data/rental/BrowserBasedItemRepository.kt
@@ -32,18 +32,29 @@ abstract class BrowserBasedItemRepository(
         val browser =
             try {
                 withTimeout(BROWSER_START_TIMEOUT_MS) {
-                    createBrowser(browserScope) { headless = true }
+                    startBrowser(browserScope)
                 }
             } catch (e: TimeoutCancellationException) {
                 browserScope.coroutineContext[Job]?.cancel()
                 logRepository.warn("$name: browser startup timed out, skipping run: ${e.message}")
                 return Page(nextPageToken = null, items = items)
+            } catch (e: CancellationException) {
+                browserScope.coroutineContext[Job]?.cancel()
+                throw e
             } catch (e: NoBrowserExecutablePathException) {
                 browserScope.coroutineContext[Job]?.cancel()
                 throw ChromeNotInstalledException(e)
             } catch (e: BrowserExecutableNotFoundException) {
                 browserScope.coroutineContext[Job]?.cancel()
                 throw ChromeNotInstalledException(e)
+            } catch (e: Exception) {
+                // Browser startup can fail transiently (e.g. a stale Chrome process or profile lock).
+                // Skip this run instead of killing the script; the next scheduled run starts fresh.
+                browserScope.coroutineContext[Job]?.cancel()
+                logRepository.warn(
+                    "$name: browser failed to start, skipping run: ${e.message ?: e::class.simpleName}",
+                )
+                return Page(nextPageToken = null, items = items)
             }
 
         try {
@@ -66,6 +77,8 @@ abstract class BrowserBasedItemRepository(
 
         return Page(nextPageToken = null, items = items)
     }
+
+    protected open suspend fun startBrowser(scope: CoroutineScope): Browser = createBrowser(scope) { headless = true }
 
     protected abstract suspend fun fetchCity(
         city: String,

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/data/rental/BrowserBasedItemRepositoryTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/data/rental/BrowserBasedItemRepositoryTest.kt
@@ -1,0 +1,50 @@
+package com.cereal.command.monitor.data.rental
+
+import com.cereal.command.monitor.fixtures.repositories.FakeLogRepository
+import com.cereal.command.monitor.models.Item
+import com.cereal.script.exception.ChromeNotInstalledException
+import dev.kdriver.core.browser.Browser
+import dev.kdriver.core.exceptions.NoBrowserExecutablePathException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class BrowserBasedItemRepositoryTest {
+    private class StartupFailureRepository(
+        private val startupError: Exception,
+    ) : BrowserBasedItemRepository(
+            cities = listOf("amsterdam"),
+            logRepository = FakeLogRepository(),
+        ) {
+        override val name: String = "Test"
+
+        override suspend fun startBrowser(scope: CoroutineScope): Browser = throw startupError
+
+        override suspend fun fetchCity(
+            city: String,
+            browser: Browser,
+        ): List<Item> = error("Should not be reached when browser startup fails")
+    }
+
+    @Test
+    fun `runtime exception during browser startup skips the run instead of throwing`() =
+        runTest {
+            val repository = StartupFailureRepository(IllegalStateException())
+
+            val page = repository.getItems(null)
+
+            assertTrue(page.items.isEmpty())
+        }
+
+    @Test
+    fun `missing browser executable still throws ChromeNotInstalledException`() =
+        runTest {
+            val repository = StartupFailureRepository(NoBrowserExecutablePathException())
+
+            assertThrows<ChromeNotInstalledException> {
+                repository.getItems(null)
+            }
+        }
+}

--- a/command/src/main/kotlin/com/cereal/script/CommandExecutionScript.kt
+++ b/command/src/main/kotlin/com/cereal/script/CommandExecutionScript.kt
@@ -97,6 +97,6 @@ class CommandExecutionScript(
     private fun Exception.toDisplayMessage(start: Instant): String =
         when (this) {
             is ChromeNotInstalledException -> message ?: "Google Chrome is not installed."
-            else -> "Error after ${start.untilNow()} while running script: $message"
+            else -> "Error after ${start.untilNow()} while running script: ${message ?: this::class.simpleName ?: "unknown error"}"
         }
 }


### PR DESCRIPTION
## Problem

The rental script crashed after 5+ days of running with:

```
[INFO] Skip retrying 'Monitoring new products' due to unhandled error
[ERROR] Error after 5d 9h 49m 24s while running script: null
```

kdriver's browser startup path throws bare `IllegalStateException`s (RuntimeExceptions), and the command-level retry policy never retries RuntimeExceptions — so a single transient Chrome startup failure (e.g. a stale process or profile lock) killed the entire long-running script. A startup *timeout* was already handled gracefully (warn + skip run), but any other startup failure was fatal.

## Fix

- `BrowserBasedItemRepository`: any exception during browser startup now logs a warning and skips the run (returning an empty page), same as the existing timeout handling. `ChromeNotInstalledException` still propagates so the friendly "Chrome is not installed" error keeps working, and `CancellationException` is still rethrown.
- `CommandExecutionScript`: when an exception has no message, fall back to its class name so errors no longer surface as `... while running script: null`.
- Extracted `startBrowser()` as an overridable hook and added unit tests covering both the skip-run and Chrome-not-installed paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)