### PR TITLE
fix: log human-readable strategy name instead of obfuscated class name

### DIFF
--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/EqualsOrBelowPriceMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/EqualsOrBelowPriceMonitorStrategy.kt
@@ -24,6 +24,8 @@ class EqualsOrBelowPriceMonitorStrategy(
     private val price: BigDecimal,
     private val currency: Currency,
 ) : MonitorStrategy {
+    override val name: String = "Equals or below price"
+
     /**
      * Determines if the user should be notified about the item based on its price.
      *

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommand.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommand.kt
@@ -46,7 +46,7 @@ class ExecuteStrategyCommand(
                 }
             }
             is MonitorStrategy.NotifyResult.Skip -> {
-                logRepository.debug("No notification for '${item.name}' using strategy '${strategy::class.simpleName}': ${result.reason}")
+                logRepository.debug("No notification for '${item.name}' using strategy '${strategy.name}': ${result.reason}")
                 false
             }
             null -> false

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MarketPriceComparisonStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MarketPriceComparisonStrategy.kt
@@ -6,6 +6,8 @@ import com.cereal.command.monitor.repository.MarketItemRepository
 class MarketPriceComparisonStrategy(
     private val marketItemRepository: MarketItemRepository,
 ) : MonitorStrategy {
+    override val name: String = "Market price comparison"
+
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/MonitorStrategy.kt
@@ -4,6 +4,14 @@ import com.cereal.command.monitor.models.Item
 
 interface MonitorStrategy {
     /**
+     * A stable, human-readable name identifying this strategy. Used for logging.
+     *
+     * This must not rely on the class name (e.g. via reflection), as class names are obfuscated
+     * in release builds and would produce meaningless output like 'cj'.
+     */
+    val name: String
+
+    /**
      * Sealed result type for [shouldNotify].
      */
     sealed class NotifyResult {

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/NewItemAvailableMonitorStrategy.kt
@@ -25,6 +25,8 @@ class NewItemAvailableMonitorStrategy(
     private val since: Instant = Clock.System.now(),
     private val requiresBaseline: Boolean = true,
 ) : MonitorStrategy {
+    override val name: String = "New item available"
+
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceChangedMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceChangedMonitorStrategy.kt
@@ -16,6 +16,8 @@ import com.cereal.command.monitor.models.getValue
  * - Suppressed when price or stock data is missing.
  */
 class PriceChangedMonitorStrategy : MonitorStrategy {
+    override val name: String = "Price changed"
+
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceDropMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/PriceDropMonitorStrategy.kt
@@ -15,6 +15,8 @@ import com.cereal.command.monitor.models.getValue
  * for the accurate functioning of the strategy.
  */
 class PriceDropMonitorStrategy : MonitorStrategy {
+    override val name: String = "Price drop"
+
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockAvailableMonitorStrategy.kt
@@ -20,6 +20,8 @@ import com.cereal.command.monitor.models.requireValue
 class StockAvailableMonitorStrategy(
     private val notifyOnInitialRun: Boolean = false,
 ) : MonitorStrategy {
+    override val name: String = "Stock available"
+
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,

--- a/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockChangedMonitorStrategy.kt
+++ b/command-monitoring/src/main/kotlin/com/cereal/command/monitor/strategy/StockChangedMonitorStrategy.kt
@@ -17,6 +17,8 @@ import com.cereal.command.monitor.models.requireValue
  * and still remain silent if no difference is determinable.
  */
 class StockChangedMonitorStrategy : MonitorStrategy {
+    override val name: String = "Stock changed"
+
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,

--- a/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
+++ b/command-monitoring/src/test/kotlin/com/cereal/command/monitor/strategy/ExecuteStrategyCommandTest.kt
@@ -6,6 +6,7 @@ import com.cereal.script.repository.LogRepository
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
@@ -62,6 +63,7 @@ class ExecuteStrategyCommandTest {
         runBlocking {
             val item = Item("TestItem", "url", "item", properties = emptyList())
 
+            every { strategy.name } returns "Test strategy"
             coEvery { strategy.shouldNotify(item, any()) } returns MonitorStrategy.NotifyResult.Skip("no reason")
             coJustRun { logRepository.debug(any()) }
 
@@ -70,6 +72,14 @@ class ExecuteStrategyCommandTest {
             executeStrategyCommand.execute()
 
             coVerify(exactly = 0) { notificationRepository.notify(any(), any()) }
-            coVerify { logRepository.debug(match { it.startsWith("No notification for 'item'") && it.contains("no reason") }) }
+            coVerify {
+                logRepository.debug(
+                    match {
+                        it.startsWith("No notification for 'item'") &&
+                            it.contains("Test strategy") &&
+                            it.contains("no reason")
+                    },
+                )
+            }
         }
 }

--- a/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
+++ b/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
@@ -11,6 +11,8 @@ class FilteredNewItemMonitorStrategy(
     private val authors: List<String>,
     private val categories: List<String>,
 ) : MonitorStrategy {
+    override val name: String = baselineStrategy.name
+
     override suspend fun shouldNotify(
         item: Item,
         previousItem: Item?,

--- a/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
+++ b/script-rss/src/main/kotlin/com/cereal/rss/FilteredNewItemMonitorStrategy.kt
@@ -11,7 +11,7 @@ class FilteredNewItemMonitorStrategy(
     private val authors: List<String>,
     private val categories: List<String>,
 ) : MonitorStrategy {
-    override val name: String = baselineStrategy.name
+    override val name: String get() = baselineStrategy.name
 
     override suspend fun shouldNotify(
         item: Item,


### PR DESCRIPTION
## What changed

The skip-notification debug log in `ExecuteStrategyCommand` used `strategy::class.simpleName` to identify the strategy. That resolves to the runtime class name, which R8/ProGuard obfuscates in release builds — producing meaningless log lines like:

> No notification for 'PLUS van Dijk : Verrassingspakket' using strategy 'cj': Not a new item

This PR adds a stable `name: String` property to the `MonitorStrategy` interface, overrides it with a human-readable label in each implementation, and logs `strategy.name` instead of the reflected class name. The log now reads:

> No notification for 'PLUS van Dijk : Verrassingspakket' using strategy 'New item available': Not a new item

## Why

Class-name reflection is unreliable for logging because release builds obfuscate names. A declared property survives obfuscation and is also clearer to read.

## Files

- `MonitorStrategy.kt` — added `name` property to the interface
- `ExecuteStrategyCommand.kt` — log `strategy.name`
- 7 strategy implementations — each overrides `name` with a readable label
- `ExecuteStrategyCommandTest.kt` — stubs `strategy.name` and asserts it appears in the log

## Notes for reviewer

- The strategy labels chosen: "New item available", "Stock available", "Stock changed", "Price drop", "Price changed", "Equals or below price", "Market price comparison". Easy to adjust if different wording is preferred.
- Verified locally: `:command-monitoring:compileKotlin` and the `ExecuteStrategyCommandTest` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)