### PR TITLE
Disable nightly CI schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,10 @@
 name: Nightly Run
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
+  # Nightly schedule disabled; run manually via workflow_dispatch when needed.
+  # schedule:
+  #   - cron: '0 6 * * *'
+  workflow_dispatch:
 
 jobs:
   integration-test:


### PR DESCRIPTION
## What

Disables the automatic nightly run of the integration-test workflow.

- Comments out the `schedule` cron trigger (`'0 6 * * *'`) in `.github/workflows/nightly.yml`.
- Adds `workflow_dispatch:` so the integration tests can still be triggered manually from the Actions tab when needed.

## Why

The nightly run is no longer wanted on an automatic schedule. Commenting out the cron (rather than deleting the file) keeps the workflow definition and its history intact, and `workflow_dispatch` preserves the ability to run it on demand.

## Notes for reviewers

No changes to the job steps themselves — only the triggers changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)